### PR TITLE
Enhance APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
                 toolchain: ${{ matrix.toolchain }}
             
             - name: Run tests
-              run: cargo test --features obographs
+              run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ontolius"
-version = "0.1.3-SNAPSHOT"
+version = "0.2.0-SNAPSHOT"
 edition = "2021"
 authors = ["Daniel Danis <daniel.gordon.danis@protonmail.com>"]
 repository = "https://github.com/ielis/ontolius"

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ let arachnodactyly: TermId = ("HP", "0001166").into();
 
 let idx = hpo.id_to_idx(&arachnodactyly)
             .expect("Arachnodacyly should be in HPO");
-let parents: Vec<_> = hierarchy.parents_of(idx)
+let parents: Vec<_> = hierarchy.iter_parents_of(idx)
                         .flat_map(|idx| hpo.idx_to_term(idx))
                         .collect();
 let names: Vec<_> = parents.iter().map(|term| term.name()).collect();

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ We use `criterion` for crate benchmarks.
 Run the following to run the bench suite:
 
 ```shell
-cargo bench --features obographs
+cargo bench
 ```
 
 The benchmark report will be written into the `target/criterion/report` directory.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The crate is *NOT* deployed on `crates.io` yet.
 We recommend adding the following into your `Cargo.toml` file:
 
 ```toml
-ontolius = { git = 'https://github.com/ielis/ontolius.git', tag = 'v0.1.2' }
+ontolius = { git = 'https://github.com/ielis/ontolius.git', tag = 'v0.2.0' }
 ```
 
 The `obographs` feature is enabled by deafult, to allow reading HPO from Obographs JSON file.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ let arachnodactyly: TermId = ("HP", "0001166").into();
 let idx = hpo.id_to_idx(&arachnodactyly)
             .expect("Arachnodacyly should be in HPO");
 let parents: Vec<_> = hierarchy.parents_of(idx)
-                        .flat_map(|idx| hpo.idx_to_term(*idx))
+                        .flat_map(|idx| hpo.idx_to_term(idx))
                         .collect();
 let names: Vec<_> = parents.iter().map(|term| term.name()).collect();
 assert_eq!(vec!["Slender finger", "Long fingers"], names);

--- a/benches/hierarchy_traversals.rs
+++ b/benches/hierarchy_traversals.rs
@@ -42,7 +42,7 @@ fn hierarchy_traversals(c: &mut Criterion) {
     let mut group = c.benchmark_group("CsrOntologyHierarchy::parents_of");
     group.throughput(criterion::Throughput::Elements(1));
     for &(label, curie) in &payload {
-        bench_traversal!(group, |term_id| hierarchy.parents_of(term_id), label, curie);
+        bench_traversal!(group, |term_id| hierarchy.iter_parents_of(term_id), label, curie);
     }
     group.finish();
 
@@ -51,7 +51,7 @@ fn hierarchy_traversals(c: &mut Criterion) {
     for &(label, curie) in &payload {
         bench_traversal!(
             group,
-            |term_id| hierarchy.ancestors_of(term_id),
+            |term_id| hierarchy.iter_ancestors_of(term_id),
             label,
             curie
         );
@@ -63,7 +63,7 @@ fn hierarchy_traversals(c: &mut Criterion) {
     for &(label, curie) in &payload {
         bench_traversal!(
             group,
-            |term_id| hierarchy.children_of(term_id),
+            |term_id| hierarchy.iter_children_of(term_id),
             label,
             curie
         );
@@ -75,7 +75,7 @@ fn hierarchy_traversals(c: &mut Criterion) {
     for &(label, curie) in &payload {
         bench_traversal!(
             group,
-            |term_id| hierarchy.descendants_of(term_id),
+            |term_id| hierarchy.iter_descendants_of(term_id),
             label,
             curie
         );

--- a/benches/hierarchy_traversals.rs
+++ b/benches/hierarchy_traversals.rs
@@ -39,14 +39,21 @@ fn hierarchy_traversals(c: &mut Criterion) {
 
     let hierarchy = ontology.hierarchy();
 
-    let mut group = c.benchmark_group("CsrOntologyHierarchy::parents_of");
+    let mut group = c.benchmark_group("CsrOntologyHierarchy::iter_parents_of");
     group.throughput(criterion::Throughput::Elements(1));
     for &(label, curie) in &payload {
         bench_traversal!(group, |term_id| hierarchy.iter_parents_of(term_id), label, curie);
     }
     group.finish();
+    let mut group = c.benchmark_group("CsrOntologyHierarchy::iter_node_and_parents_of");
+    group.throughput(criterion::Throughput::Elements(1));
+    for &(label, curie) in &payload {
+        bench_traversal!(group, |term_id| hierarchy.iter_node_and_parents_of(term_id), label, curie);
+    }
+    group.finish();
 
-    let mut group = c.benchmark_group("CsrOntologyHierarchy::ancestors_of");
+
+    let mut group = c.benchmark_group("CsrOntologyHierarchy::iter_ancestors_of");
     group.throughput(criterion::Throughput::Elements(1));
     for &(label, curie) in &payload {
         bench_traversal!(
@@ -57,8 +64,20 @@ fn hierarchy_traversals(c: &mut Criterion) {
         );
     }
     group.finish();
+    let mut group = c.benchmark_group("CsrOntologyHierarchy::iter_node_and_ancestors_of");
+    group.throughput(criterion::Throughput::Elements(1));
+    for &(label, curie) in &payload {
+        bench_traversal!(
+            group,
+            |term_id| hierarchy.iter_node_and_ancestors_of(term_id),
+            label,
+            curie
+        );
+    }
+    group.finish();
 
-    let mut group = c.benchmark_group("CsrOntologyHierarchy::children_of");
+
+    let mut group = c.benchmark_group("CsrOntologyHierarchy::iter_children_of");
     group.throughput(criterion::Throughput::Elements(1));
     for &(label, curie) in &payload {
         bench_traversal!(
@@ -69,13 +88,36 @@ fn hierarchy_traversals(c: &mut Criterion) {
         );
     }
     group.finish();
+    let mut group = c.benchmark_group("CsrOntologyHierarchy::iter_node_and_children_of");
+    group.throughput(criterion::Throughput::Elements(1));
+    for &(label, curie) in &payload {
+        bench_traversal!(
+            group,
+            |term_id| hierarchy.iter_node_and_children_of(term_id),
+            label,
+            curie
+        );
+    }
+    group.finish();
 
-    let mut group = c.benchmark_group("CsrOntologyHierarchy::descendants_of");
+    
+    let mut group = c.benchmark_group("CsrOntologyHierarchy::iter_descendants_of");
     group.throughput(criterion::Throughput::Elements(1));
     for &(label, curie) in &payload {
         bench_traversal!(
             group,
             |term_id| hierarchy.iter_descendants_of(term_id),
+            label,
+            curie
+        );
+    }
+    group.finish();
+    let mut group = c.benchmark_group("CsrOntologyHierarchy::iter_node_and_descendants_of");
+    group.throughput(criterion::Throughput::Elements(1));
+    for &(label, curie) in &payload {
+        bench_traversal!(
+            group,
+            |term_id| hierarchy.iter_node_and_descendants_of(term_id),
             label,
             curie
         );

--- a/src/hierarchy/edge.rs
+++ b/src/hierarchy/edge.rs
@@ -4,6 +4,8 @@ use std::hash::Hash;
 use super::HierarchyIdx;
 
 /// A relationship between the ontology concepts.
+///
+/// At this time, we only support `is_a` relationship.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Relationship {
     /// Subject is the parent of the object.
@@ -19,14 +21,21 @@ pub enum Relationship {
 /// * [`Relationship`] with one of supported relationships
 /// * `I` with the index of the destination term
 #[derive(Debug, Clone, Hash)]
-pub struct GraphEdge<I: HierarchyIdx> {
+pub struct GraphEdge<I> {
     pub sub: I,
     pub pred: Relationship,
     pub obj: I,
 }
 
-impl<I: HierarchyIdx> From<(I, Relationship, I)> for GraphEdge<I> {
+impl<I> From<(I, Relationship, I)> for GraphEdge<I>
+where
+    I: HierarchyIdx,
+{
     fn from(value: (I, Relationship, I)) -> Self {
-        Self { sub: value.0, pred: value.1, obj: value.2 }
+        Self {
+            sub: value.0,
+            pred: value.1,
+            obj: value.2,
+        }
     }
 }

--- a/src/hierarchy/mod.rs
+++ b/src/hierarchy/mod.rs
@@ -21,15 +21,15 @@ pub trait ChildNodes {
         Self::I: 'a;
 
     /// Returns an iterator of all nodes which are children of `node`.
-    fn children_of(&self, node: Self::I) -> Self::ChildIter<'_>;
+    fn children_of(&self, node: &Self::I) -> Self::ChildIter<'_>;
 
     /// Test if `sub` is child of the `obj` node.
-    fn is_child_of(&self, sub: Self::I, obj: Self::I) -> bool {
-        self.children_of(obj).any(|&child| child == sub)
+    fn is_child_of(&self, sub: &Self::I, obj: &Self::I) -> bool {
+        self.children_of(obj).any(|child| *child == *sub)
     }
 
     /// Test if `node` is a leaf, i.e. a node with no child nodes.
-    fn is_leaf(&self, node: Self::I) -> bool {
+    fn is_leaf(&self, node: &Self::I) -> bool {
         self.children_of(node).count() == 0
     }
 }
@@ -44,7 +44,7 @@ pub trait DescendantNodes {
         Self::I: 'a;
 
     /// Returns an iterator of all nodes which are descendants of `node`.
-    fn descendants_of(&self, node: Self::I) -> Self::DescendantIter<'_>;
+    fn descendants_of(&self, node: &Self::I) -> Self::DescendantIter<'_>;
 }
 
 /// Trait for types that can provide the parent nodes of an ontology node.
@@ -57,11 +57,11 @@ pub trait ParentNodes {
         Self::I: 'a;
 
     /// Returns an iterator of all nodes which are parents of `node`.
-    fn parents_of(&self, node: Self::I) -> Self::ParentIter<'_>;
+    fn parents_of(&self, node: &Self::I) -> Self::ParentIter<'_>;
 
     /// Test if `sub` is parent of the `obj` node.
-    fn is_parent_of(&self, sub: Self::I, obj: Self::I) -> bool {
-        self.parents_of(obj).any(|&parent| parent == sub)
+    fn is_parent_of(&self, sub: &Self::I, obj: &Self::I) -> bool {
+        self.parents_of(obj).any(|parent| *parent == *sub)
     }
 }
 
@@ -75,16 +75,16 @@ pub trait AncestorNodes {
         Self::I: 'a;
 
     /// Returns an iterator of all nodes which are ancestors of `node`.
-    fn ancestors_of(&self, node: Self::I) -> Self::AncestorIter<'_>;
+    fn ancestors_of(&self, node: &Self::I) -> Self::AncestorIter<'_>;
 
     /// Test if `sub` is an ancestor of `obj`.
-    fn is_ancestor_of(&self, sub: Self::I, obj: Self::I) -> bool {
-        self.ancestors_of(obj).any(|&anc| anc == sub)
+    fn is_ancestor_of(&self, sub: &Self::I, obj: &Self::I) -> bool {
+        self.ancestors_of(obj).any(|anc| *anc == *sub)
     }
 
     /// Test if `sub`` is a descendant of `obj`.
-    fn is_descendant_of(&self, sub: Self::I, obj: Self::I) -> bool {
-        self.ancestors_of(sub).any(|&parent| parent == obj)
+    fn is_descendant_of(&self, sub: &Self::I, obj: &Self::I) -> bool {
+        self.ancestors_of(sub).any(|parent| *parent == *obj)
     }
 }
 
@@ -105,8 +105,7 @@ pub trait OntologyHierarchy:
 
     // TODO: augment a container with ancestors & self
     // TODO: augment a container with descendants & self
-
-    fn subhierarchy(&self, subroot_idx: Self::HI) -> Self;
+    fn subhierarchy(&self, subroot_idx: &Self::HI) -> Self;
 }
 
 /// The implementors can be used to index the [`super::OntologyHierarchy`].

--- a/src/hierarchy/mod.rs
+++ b/src/hierarchy/mod.rs
@@ -15,22 +15,50 @@ pub use edge::{GraphEdge, Relationship};
 pub trait ChildNodes {
     // Type used to index the ontology nodes.
     type I: HierarchyIdx;
-    type ChildIter<'a>: Iterator<Item = &'a Self::I>
-    where
-        Self: 'a,
-        Self::I: 'a;
 
     /// Returns an iterator of all nodes which are children of `node`.
-    fn children_of(&self, node: &Self::I) -> Self::ChildIter<'_>;
+    #[deprecated(since = "0.1.3", note = "Use `iter_children_of` instead")]
+    fn children_of(&self, node: &Self::I) -> impl Iterator<Item = &Self::I> {
+        self.iter_children_of(node)
+    }
+
+    /// Returns an iterator of all nodes which are children of `node`.
+    fn iter_children_of(&self, node: &Self::I) -> impl Iterator<Item = &Self::I>;
 
     /// Test if `sub` is child of the `obj` node.
     fn is_child_of(&self, sub: &Self::I, obj: &Self::I) -> bool {
-        self.children_of(obj).any(|child| *child == *sub)
+        self.iter_children_of(obj).any(|child| *child == *sub)
     }
 
     /// Test if `node` is a leaf, i.e. a node with no child nodes.
     fn is_leaf(&self, node: &Self::I) -> bool {
-        self.children_of(node).count() == 0
+        self.iter_children_of(node).count() == 0
+    }
+
+    /// Get an iterator for iterating over a node followed by all its children.
+    fn iter_node_and_children_of<'a>(
+        &'a self,
+        node: &'a Self::I,
+    ) -> impl Iterator<Item = &'a Self::I> {
+        std::iter::once(node).chain(self.iter_children_of(node))
+    }
+
+    /// Augment the collection with children of the `source` node.
+    fn augment_with_children<'a, T>(&'a self, source: &Self::I, collection: &mut T)
+    where
+        T: Extend<&'a Self::I>,
+        Self: 'a,
+    {
+        collection.extend(self.iter_children_of(source))
+    }
+
+    /// Augment the collection with the source `node` and its children.
+    fn augment_with_node_and_children<'a, T>(&'a self, node: &'a Self::I, collection: &mut T)
+    where
+        T: Extend<&'a Self::I>,
+        Self: 'a,
+    {
+        collection.extend(self.iter_node_and_children_of(node));
     }
 }
 
@@ -38,30 +66,86 @@ pub trait ChildNodes {
 pub trait DescendantNodes {
     // Type used to index the ontology nodes.
     type I: HierarchyIdx;
-    type DescendantIter<'a>: Iterator<Item = &'a Self::I>
-    where
-        Self: 'a,
-        Self::I: 'a;
 
     /// Returns an iterator of all nodes which are descendants of `node`.
-    fn descendants_of(&self, node: &Self::I) -> Self::DescendantIter<'_>;
+    #[deprecated(since = "0.1.3", note = "Use `iter_descendants_of` instead")]
+    fn descendants_of(&self, node: &Self::I) -> impl Iterator<Item = &Self::I> {
+        self.iter_descendants_of(node)
+    }
+
+    /// Returns an iterator of all nodes which are descendants of `node`.
+    fn iter_descendants_of(&self, node: &Self::I) -> impl Iterator<Item = &Self::I>;
+
+    /// Get an iterator for iterating over a node followed by all its descendants.
+    fn iter_node_and_descendants_of<'a>(
+        &'a self,
+        node: &'a Self::I,
+    ) -> impl Iterator<Item = &'a Self::I> {
+        std::iter::once(node).chain(self.iter_descendants_of(node))
+    }
+
+    /// Augment the collection with *descendants* of the source `node`.
+    fn augment_with_descendants<'a, T>(&'a self, node: &Self::I, collection: &mut T)
+    where
+        T: Extend<&'a Self::I>,
+        Self: 'a,
+    {
+        collection.extend(self.iter_descendants_of(node))
+    }
+
+    /// Augment the collection with the source `node` and its *descendants*.
+    fn augment_with_source_and_descendants<'a, T>(&'a self, node: &'a Self::I, collection: &mut T)
+    where
+        T: Extend<&'a Self::I>,
+        Self: 'a,
+    {
+        collection.extend(self.iter_descendants_of(node));
+    }
 }
 
 /// Trait for types that can provide the parent nodes of an ontology node.
 pub trait ParentNodes {
     // Type used to index the ontology nodes.
     type I: HierarchyIdx;
-    type ParentIter<'a>: Iterator<Item = &'a Self::I>
-    where
-        Self: 'a,
-        Self::I: 'a;
 
     /// Returns an iterator of all nodes which are parents of `node`.
-    fn parents_of(&self, node: &Self::I) -> Self::ParentIter<'_>;
+    #[deprecated(since = "0.1.3", note = "Use `iter_parents_of` instead")]
+    fn parents_of(&self, node: &Self::I) -> impl Iterator<Item = &Self::I> {
+        self.iter_parents_of(node)
+    }
+
+    /// Returns an iterator of all nodes which are parents of `node`.
+    fn iter_parents_of(&self, node: &Self::I) -> impl Iterator<Item = &Self::I>;
 
     /// Test if `sub` is parent of the `obj` node.
     fn is_parent_of(&self, sub: &Self::I, obj: &Self::I) -> bool {
-        self.parents_of(obj).any(|parent| *parent == *sub)
+        self.iter_parents_of(obj).any(|parent| *parent == *sub)
+    }
+
+    /// Get an iterator for iterating over a node followed by all its parents.
+    fn iter_node_and_parents_of<'a>(
+        &'a self,
+        node: &'a Self::I,
+    ) -> impl Iterator<Item = &'a Self::I> {
+        std::iter::once(node).chain(self.iter_parents_of(node))
+    }
+
+    /// Augment the collection with *parents* of the source `node`.
+    fn augment_with_parents<'a, T>(&'a self, node: &Self::I, collection: &mut T)
+    where
+        T: Extend<&'a Self::I>,
+        Self: 'a,
+    {
+        collection.extend(self.iter_parents_of(node))
+    }
+
+    /// Augment the collection with the source `node` and its *parents*.
+    fn augment_with_source_and_parents<'a, T>(&'a self, node: &'a Self::I, collection: &mut T)
+    where
+        T: Extend<&'a Self::I>,
+        Self: 'a,
+    {
+        collection.extend(self.iter_node_and_parents_of(node));
     }
 }
 
@@ -69,22 +153,50 @@ pub trait ParentNodes {
 pub trait AncestorNodes {
     // Type used to index the ontology nodes.
     type I: HierarchyIdx;
-    type AncestorIter<'a>: Iterator<Item = &'a Self::I>
-    where
-        Self: 'a,
-        Self::I: 'a;
 
     /// Returns an iterator of all nodes which are ancestors of `node`.
-    fn ancestors_of(&self, node: &Self::I) -> Self::AncestorIter<'_>;
+    #[deprecated(since = "0.1.3", note = "Use `iter_ancestors_of` instead")]
+    fn ancestors_of(&self, node: &Self::I) -> impl Iterator<Item = &Self::I> {
+        self.iter_ancestors_of(node)
+    }
+
+    /// Returns an iterator of all nodes which are ancestors of `node`.
+    fn iter_ancestors_of(&self, node: &Self::I) -> impl Iterator<Item = &Self::I>;
 
     /// Test if `sub` is an ancestor of `obj`.
     fn is_ancestor_of(&self, sub: &Self::I, obj: &Self::I) -> bool {
-        self.ancestors_of(obj).any(|anc| *anc == *sub)
+        self.iter_ancestors_of(obj).any(|anc| *anc == *sub)
     }
 
     /// Test if `sub`` is a descendant of `obj`.
     fn is_descendant_of(&self, sub: &Self::I, obj: &Self::I) -> bool {
-        self.ancestors_of(sub).any(|parent| *parent == *obj)
+        self.iter_ancestors_of(sub).any(|parent| *parent == *obj)
+    }
+
+    /// Get an iterator for iterating over a node followed by all its ancestors.
+    fn iter_node_and_ancestors_of<'a>(
+        &'a self,
+        node: &'a Self::I,
+    ) -> impl Iterator<Item = &'a Self::I> {
+        std::iter::once(node).chain(self.iter_ancestors_of(node))
+    }
+
+    /// Augment the collection with *ancestors* of the source `node`.
+    fn augment_with_ancestors<'a, T>(&'a self, node: &Self::I, collection: &mut T)
+    where
+        T: Extend<&'a Self::I>,
+        Self: 'a,
+    {
+        collection.extend(self.iter_ancestors_of(node))
+    }
+
+    /// Augment the collection with the source `node` and its *ancestors*.
+    fn augment_with_node_and_ancestors<'a, T>(&'a self, node: &'a Self::I, collection: &mut T)
+    where
+        T: Extend<&'a Self::I>,
+        Self: 'a,
+    {
+        collection.extend(self.iter_node_and_ancestors_of(node));
     }
 }
 
@@ -103,8 +215,6 @@ pub trait OntologyHierarchy:
     /// Get index of the root element.
     fn root(&self) -> &Self::HI;
 
-    // TODO: augment a container with ancestors & self
-    // TODO: augment a container with descendants & self
     fn subhierarchy(&self, subroot_idx: &Self::HI) -> Self;
 }
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -17,36 +17,18 @@ use crate::{
 };
 
 pub struct OntologyData<HI, T>
+{
+    pub terms: Vec<T>,
+    pub edges: Vec<GraphEdge<HI>>,
+    pub metadata: HashMap<String, String>,
+}
+
+impl<HI, T> From<(Vec<T>, Vec<GraphEdge<HI>>, HashMap<String, String>)> for OntologyData<HI, T>
 where
     HI: HierarchyIdx,
     T: MinimalTerm,
 {
-    terms: Box<[T]>,
-    edges: Box<[GraphEdge<HI>]>,
-    metadata: HashMap<String, String>,
-}
-
-impl<HI: HierarchyIdx, T: MinimalTerm> OntologyData<HI, T> {
-    pub fn terms(&self) -> &[T] {
-        &self.terms
-    }
-
-    pub fn edges(&self) -> &[GraphEdge<HI>] {
-        &self.edges
-    }
-
-    pub fn metadata(&self) -> &HashMap<String, String> {
-        // TODO: the signature overpromises. We should probably only promise an iterator over (String, String).
-        &self.metadata
-    }
-}
-
-impl<HI, T> From<(Box<[T]>, Box<[GraphEdge<HI>]>, HashMap<String, String>)> for OntologyData<HI, T>
-where
-    HI: HierarchyIdx,
-    T: MinimalTerm,
-{
-    fn from(value: (Box<[T]>, Box<[GraphEdge<HI>]>, HashMap<String, String>)) -> Self {
+    fn from(value: (Vec<T>, Vec<GraphEdge<HI>>, HashMap<String, String>)) -> Self {
         Self {
             terms: value.0,
             edges: value.1,

--- a/src/io/obographs.rs
+++ b/src/io/obographs.rs
@@ -126,8 +126,8 @@ where
             let metadata = HashMap::new(); // TODO: parse out metadata
 
             Ok(OntologyData::from((
-                terms.into_boxed_slice(),
-                edges.into_boxed_slice(),
+                terms,
+                edges,
                 metadata,
             )))
         } else {

--- a/src/ontology/csr/hierarchy.rs
+++ b/src/ontology/csr/hierarchy.rs
@@ -93,9 +93,8 @@ where
     I: CsrIdx + HierarchyIdx + Hash,
 {
     type I = I;
-    type ChildIter<'a> = std::slice::Iter<'a, I> where I: 'a;
 
-    fn children_of(&self, node: &I) -> Self::ChildIter<'_> {
+    fn iter_children_of(&self, node: &I) -> impl Iterator<Item = &Self::I> {
         self.adjacency_matrix.in_neighbors(*node)
     }
 }
@@ -105,9 +104,8 @@ where
     I: CsrIdx + HierarchyIdx + Hash,
 {
     type I = I;
-    type ParentIter<'a> = std::slice::Iter<'a, I> where I: 'a;
 
-    fn parents_of(&self, node: &I) -> Self::ParentIter<'_> {
+    fn iter_parents_of(&self, node: &I) -> impl Iterator<Item = &Self::I> {
         self.adjacency_matrix.out_neighbors(*node)
     }
 }
@@ -117,9 +115,8 @@ where
     I: CsrIdx + HierarchyIdx + Hash,
 {
     type I = I;
-    type DescendantIter<'a> = DescendantsIter<'a, I>;
 
-    fn descendants_of(&self, node: &I) -> Self::DescendantIter<'_> {
+    fn iter_descendants_of(&self, node: &I) -> impl Iterator<Item = &Self::I> {
         DescendantsIter {
             adjacency_matrix: &self.adjacency_matrix,
             seen: HashSet::new(),
@@ -160,11 +157,8 @@ where
     I: CsrIdx + HierarchyIdx + Hash,
 {
     type I = I;
-    type AncestorIter<'a> = AncestorIter<'a, I>
-    where
-        Self: 'a;
 
-    fn ancestors_of(&self, node: &I) -> Self::AncestorIter<'_> {
+    fn iter_ancestors_of(&self, node: &I) -> impl Iterator<Item = &Self::I> {
         AncestorIter {
             adjacency_matrix: &self.adjacency_matrix,
             seen: HashSet::new(),
@@ -214,8 +208,8 @@ where
     fn subhierarchy(&self, subroot: &I) -> Self {
         // TODO: implement
         let mut edge_map: HashMap<&I, HashSet<&I>> = HashMap::new();
-        for descendant in std::iter::once(subroot).chain(self.descendants_of(subroot)) {
-            for child in self.children_of(descendant) {
+        for descendant in self.iter_node_and_descendants_of(subroot) {
+            for child in self.iter_children_of(descendant) {
                 edge_map.entry(child).or_default().insert(descendant);
             }
         }
@@ -259,9 +253,9 @@ mod test_hierarchy {
     }
 
     #[test]
-    fn test_children_of() {
+    fn test_iter_children_of() {
         let hierarchy = build_example_hierarchy();
-        let func = CsrOntologyHierarchy::children_of;
+        let func = CsrOntologyHierarchy::iter_children_of;
 
         check_members!(hierarchy, func, &0, [1, 5, 9]);
         check_members!(hierarchy, func, &1, [2, 3]);
@@ -276,9 +270,26 @@ mod test_hierarchy {
     }
 
     #[test]
-    fn test_descendants_of() {
+    fn test_iter_node_and_children_of() {
         let hierarchy = build_example_hierarchy();
-        let func = CsrOntologyHierarchy::descendants_of;
+        let func = CsrOntologyHierarchy::iter_node_and_children_of;
+
+        check_members!(hierarchy, func, &0, [0, 1, 5, 9]);
+        check_members!(hierarchy, func, &1, [1, 2, 3]);
+        check_members!(hierarchy, func, &2, [2, 4]);
+        check_members!(hierarchy, func, &3, [3, 4]);
+        check_members!(hierarchy, func, &4, [4]);
+        check_members!(hierarchy, func, &5, [5, 6, 7, 8]);
+        check_members!(hierarchy, func, &6, [6]);
+        check_members!(hierarchy, func, &7, [7]);
+        check_members!(hierarchy, func, &8, [8]);
+        check_members!(hierarchy, func, &9, [9]);
+    }
+
+    #[test]
+    fn test_iter_descendants_of() {
+        let hierarchy = build_example_hierarchy();
+        let func = CsrOntologyHierarchy::iter_descendants_of;
 
         check_members!(hierarchy, func, &0, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
         check_members!(hierarchy, func, &1, [2, 3, 4]);
@@ -293,9 +304,26 @@ mod test_hierarchy {
     }
 
     #[test]
-    fn test_parents_of() {
+    fn test_iter_node_and_descendants_of() {
         let hierarchy = build_example_hierarchy();
-        let func = CsrOntologyHierarchy::parents_of;
+        let func = CsrOntologyHierarchy::iter_node_and_descendants_of;
+
+        check_members!(hierarchy, func, &0, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        check_members!(hierarchy, func, &1, [1, 2, 3, 4]);
+        check_members!(hierarchy, func, &2, [2, 4]);
+        check_members!(hierarchy, func, &3, [3, 4]);
+        check_members!(hierarchy, func, &4, [4]);
+        check_members!(hierarchy, func, &5, [5, 6, 7, 8]);
+        check_members!(hierarchy, func, &6, [6]);
+        check_members!(hierarchy, func, &7, [7]);
+        check_members!(hierarchy, func, &8, [8]);
+        check_members!(hierarchy, func, &9, [9]);
+    }
+
+    #[test]
+    fn test_iter_parents_of() {
+        let hierarchy = build_example_hierarchy();
+        let func = CsrOntologyHierarchy::iter_parents_of;
 
         check_members!(hierarchy, func, &0, [0; 0]);
         check_members!(hierarchy, func, &1, [0]);
@@ -310,9 +338,26 @@ mod test_hierarchy {
     }
 
     #[test]
-    fn test_ancestors_of() {
+    fn test_iter_node_and_parents_of() {
         let hierarchy = build_example_hierarchy();
-        let func = CsrOntologyHierarchy::ancestors_of;
+        let func = CsrOntologyHierarchy::iter_node_and_parents_of;
+
+        check_members!(hierarchy, func, &0, [0]);
+        check_members!(hierarchy, func, &1, [1, 0]);
+        check_members!(hierarchy, func, &2, [2, 1]);
+        check_members!(hierarchy, func, &3, [3, 1]);
+        check_members!(hierarchy, func, &4, [4, 2, 3]);
+        check_members!(hierarchy, func, &5, [5, 0]);
+        check_members!(hierarchy, func, &6, [6, 5]);
+        check_members!(hierarchy, func, &7, [7, 5]);
+        check_members!(hierarchy, func, &8, [8, 5]);
+        check_members!(hierarchy, func, &9, [9, 0]);
+    }
+
+    #[test]
+    fn test_iter_ancestors_of() {
+        let hierarchy = build_example_hierarchy();
+        let func = CsrOntologyHierarchy::iter_ancestors_of;
 
         check_members!(hierarchy, func, &0, [0; 0]);
         check_members!(hierarchy, func, &1, [0]);
@@ -324,6 +369,23 @@ mod test_hierarchy {
         check_members!(hierarchy, func, &7, [0, 5]);
         check_members!(hierarchy, func, &8, [0, 5]);
         check_members!(hierarchy, func, &9, [0]);
+    }
+
+    #[test]
+    fn test_iter_node_and_ancestors_of() {
+        let hierarchy = build_example_hierarchy();
+        let func = CsrOntologyHierarchy::iter_node_and_ancestors_of;
+
+        check_members!(hierarchy, func, &0, [0]);
+        check_members!(hierarchy, func, &1, [1, 0]);
+        check_members!(hierarchy, func, &2, [2, 0, 1]);
+        check_members!(hierarchy, func, &3, [3, 0, 1]);
+        check_members!(hierarchy, func, &4, [4, 0, 1, 2, 3]);
+        check_members!(hierarchy, func, &5, [5, 0]);
+        check_members!(hierarchy, func, &6, [6, 0, 5]);
+        check_members!(hierarchy, func, &7, [7, 0, 5]);
+        check_members!(hierarchy, func, &8, [8, 0, 5]);
+        check_members!(hierarchy, func, &9, [9, 0]);
     }
 
     fn build_example_hierarchy() -> CsrOntologyHierarchy<u16> {

--- a/src/ontology/mod.rs
+++ b/src/ontology/mod.rs
@@ -19,7 +19,7 @@ macro_rules! impl_idx {
                 *self as usize
             }
         }
-    }
+    };
 }
 
 impl_idx!(u8);
@@ -219,9 +219,9 @@ pub trait Ontology:
     TermAware<TI = Self::Idx, Term = Self::T> + HierarchyAware<HI = Self::Idx> + MetadataAware
 {
     /// The indexer for the terms and ontology graph nodes.
-    /// 
-    /// Note, `Hash` is not necessarily used for the ontology functionality. 
-    /// However, we include the bound to increase user convenience, 
+    ///
+    /// Note, `Hash` is not necessarily used for the ontology functionality.
+    /// However, we include the bound to increase user convenience,
     /// e.g. to support creating hash sets/maps of the vanilla ontology indices.
     type Idx: TermIdx + HierarchyIdx + Hash;
     /// The term type.
@@ -234,10 +234,7 @@ pub trait Ontology:
     }
 
     /// Get the term ID of the root term of the ontology.
-    fn root_term_id<'a>(&'a self) -> &'a TermId
-    where
-        Self::T: 'a,
-    {
+    fn root_term_id(&self) -> &TermId {
         self.root_term().identifier()
     }
 }

--- a/src/ontology/mod.rs
+++ b/src/ontology/mod.rs
@@ -1,22 +1,22 @@
 //! A module with the ontology parts.
 pub mod csr;
 
+use std::hash::Hash;
+
 use crate::base::{term::MinimalTerm, Identified, TermId};
 use crate::hierarchy::{HierarchyIdx, OntologyHierarchy};
 
 /// The implementors can be used to index the [`super::TermAware`].
 pub trait TermIdx: Copy {
-
     // Convert the index to `usize` for indexing.
-    fn index(self) -> usize;
-
+    fn index(&self) -> usize;
 }
 
 macro_rules! impl_idx {
     ($TYPE:ty) => {
         impl TermIdx for $TYPE {
-            fn index(self) -> usize {
-                self as usize
+            fn index(&self) -> usize {
+                *self as usize
             }
         }
     }
@@ -34,7 +34,6 @@ impl_idx!(i32);
 impl_idx!(i64);
 impl_idx!(isize);
 
-
 /// A trait for types that act as a containers of the ontology terms.
 ///
 /// The container supports iteration over the terms, to retrieve a term
@@ -47,21 +46,16 @@ pub trait TermAware {
     where
         Self: 'a;
 
-    /// Get the iterator over the ontology terms.
-    ///
-    /// Note: as of now, we intentionally do not specify
-    /// if the iterator includes the obsolete terms.
-    /// It depends on the implementation and we must
-    /// work out the requirements!
+    /// Get the iterator over the *primary* ontology terms.
     fn iter_terms(&self) -> Self::TermIter<'_>;
 
     /// Map index to a [`TermAware::Term`] of the ontology.
     ///
     /// Returns `None` if there is no such term for the input `idx` in the ontology.
-    fn idx_to_term(&self, idx: Self::TI) -> Option<&Self::Term>;
+    fn idx_to_term(&self, idx: &Self::TI) -> Option<&Self::Term>;
 
     /// Get the index corresponding to a [`TermAware::Term`] for given ID.
-    fn id_to_idx<ID>(&self, id: &ID) -> Option<Self::TI>
+    fn id_to_idx<ID>(&self, id: &ID) -> Option<&Self::TI>
     where
         ID: Identified;
 
@@ -86,7 +80,7 @@ pub trait TermAware {
     }
 
     /// Get the term ID of a term stored under given `idx`.
-    fn idx_to_term_id(&self, idx: Self::TI) -> Option<&TermId> {
+    fn idx_to_term_id(&self, idx: &Self::TI) -> Option<&TermId> {
         match self.idx_to_term(idx) {
             Some(term) => Some(term.identifier()),
             None => None,
@@ -98,14 +92,19 @@ pub trait TermAware {
         self.iter_terms().count()
     }
 
-    /// Iterate over term IDs of the *current* terms.
+    /// Test if the ontology includes no terms.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Iterate over term IDs of the *primary* terms.
     fn iter_term_ids(&self) -> TermIdIter<'_, Self::Term> {
         TermIdIter {
             terms: Box::new(self.iter_terms()),
         }
     }
 
-    /// Iterate over term IDs of *all* terms (current and obsolete).
+    /// Iterate over term IDs of *all* terms (primary and obsolete).
     fn iter_all_term_ids(&self) -> AllTermIdsIter<'_, Self::Term> {
         AllTermIdsIter {
             state: State::Primary,
@@ -220,13 +219,17 @@ pub trait Ontology:
     TermAware<TI = Self::Idx, Term = Self::T> + HierarchyAware<HI = Self::Idx> + MetadataAware
 {
     /// The indexer for the terms and ontology graph nodes.
-    type Idx: TermIdx + HierarchyIdx;
+    /// 
+    /// Note, `Hash` is not necessarily used for the ontology functionality. 
+    /// However, we include the bound to increase user convenience, 
+    /// e.g. to support creating hash sets/maps of the vanilla ontology indices.
+    type Idx: TermIdx + HierarchyIdx + Hash;
     /// The term type.
     type T: MinimalTerm;
 
     /// Get the root term.
     fn root_term(&self) -> &Self::T {
-        self.idx_to_term(*self.hierarchy().root())
+        self.idx_to_term(self.hierarchy().root())
             .expect("Ontology should contain a term for term index")
     }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -22,3 +22,4 @@ pub use crate::ontology::HierarchyAware;
 pub use crate::ontology::Ontology;
 pub use crate::ontology::TermAware;
 pub use crate::ontology::TermIdx;
+pub use crate::ontology::MetadataAware;


### PR DESCRIPTION
- Work with index references instead of owned index values
- Simplify ontology hierarchy traversal traits by using `impl Iterator` instead of an explicit iterator associated item. Allow including the source node in the iteration over term indices
- Support augmentating structs that implement `Extend<T>` with term indices