### PR TITLE
BREAKING: Revamp hierarchy traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ontolius"
-version = "0.3.2-dev0"
+version = "0.4.0-dev0"
 edition = "2021"
 authors = ["Daniel Danis <daniel.gordon.danis@protonmail.com>"]
 repository = "https://github.com/ielis/ontolius"

--- a/benches/hierarchy_io.rs
+++ b/benches/hierarchy_io.rs
@@ -6,9 +6,7 @@ use ontolius::ontology::csr::MinimalCsrOntology;
 fn load_csr_ontology(c: &mut Criterion) {
     let path = "resources/hp.v2024-08-13.json.gz";
 
-    let loader = OntologyLoaderBuilder::new()
-        .obographs_parser()
-        .build();
+    let loader = OntologyLoaderBuilder::new().obographs_parser().build();
 
     let mut group = c.benchmark_group("CsrOntologyLoader");
     group.bench_function("CsrOntologyLoader::load", |b| {

--- a/benches/term_ids.rs
+++ b/benches/term_ids.rs
@@ -6,34 +6,33 @@ use ontolius::base::TermId;
 fn bench_term_id(c: &mut Criterion) {
     // Bench parsing CURIE parts.
     let mut group = c.benchmark_group("TermId");
-    group.bench_function(BenchmarkId::from_parameter("TermId::from known"), 
-    |b| {
+    group.bench_function(BenchmarkId::from_parameter("TermId::from known"), |b| {
         b.iter(|| {
             black_box(TermId::from(("HP", "0001250")));
         })
     });
 
-    group.bench_function(BenchmarkId::from_parameter("TermId::from random"), 
-    |b| {
+    group.bench_function(BenchmarkId::from_parameter("TermId::from random"), |b| {
         b.iter(|| {
             black_box(TermId::from(("MP", "0001250")));
         })
     });
 
     // Bench parsing the entire CURIEs.
-    group.bench_function(BenchmarkId::from_parameter("TermId::from_str known"), 
-    |b| {
+    group.bench_function(BenchmarkId::from_parameter("TermId::from_str known"), |b| {
         b.iter(|| {
             black_box(TermId::from_str("HP:0001250").expect("This curie should be parsable!"));
         })
     });
 
-    group.bench_function(BenchmarkId::from_parameter("TermId::from_str random"), 
-    |b| {
-        b.iter(|| {
-            black_box(TermId::from_str("MP:0001250").expect("This curie should be parsable!"));
-        })
-    });
+    group.bench_function(
+        BenchmarkId::from_parameter("TermId::from_str random"),
+        |b| {
+            b.iter(|| {
+                black_box(TermId::from_str("MP:0001250").expect("This curie should be parsable!"));
+            })
+        },
+    );
     group.finish();
 }
 

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -5,7 +5,7 @@ use std::fmt::{Display, Formatter, Write};
 use std::hash::Hash;
 use std::str::FromStr;
 
-use anyhow::{Error, bail, Result};
+use anyhow::{bail, Error, Result};
 
 #[cfg(feature = "pyo3")]
 pub mod py;
@@ -28,7 +28,6 @@ pub mod term;
 pub trait Identified {
     fn identifier(&self) -> &TermId;
 }
-
 
 /// Identifier of an ontology concept.
 ///
@@ -86,12 +85,12 @@ impl FromStr for TermId {
 }
 
 /// Test if a tuple with *prefix* and *id* tuple is equal to a term ID.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```
 /// use ontolius::prelude::*;
-/// 
+///
 /// assert_eq!(TermId::from(("HP", "0001250")), ("HP", "0001250"));
 /// assert_eq!(TermId::from(("NCIT", "C2852")), ("NCIT", "C2852"));
 /// ```
@@ -100,34 +99,36 @@ impl PartialEq<(&str, &str)> for TermId {
         match &self.0 {
             InnerTermId::Known(prefix, id, len) => {
                 if prefix.eq(other.0) {
-                    match (other.1.parse::<u32>(), u8::try_from(other.1.chars().count())) {
-                        (Ok(parsed_id), Ok(parsed_len)) => {
-                            *id == parsed_id && *len == parsed_len
-                        },
-                        _ => false
+                    match (
+                        other.1.parse::<u32>(),
+                        u8::try_from(other.1.chars().count()),
+                    ) {
+                        (Ok(parsed_id), Ok(parsed_len)) => *id == parsed_id && *len == parsed_len,
+                        _ => false,
                     }
                 } else {
                     false
                 }
             }
             InnerTermId::Random(val, idx) => {
-                /* Prefix */ &val[..*idx as usize] == other.0 
-                /* Id */     && other.1 == &val[*idx as usize..] 
+                /* Prefix */
+                &val[..*idx as usize] == other.0
+                /* Id */     && other.1 == &val[*idx as usize..]
             }
         }
     }
 }
 
 /// Test if a tuple with *prefix* and *id* tuple is equal to a reference to a term ID.
-/// 
+///
 /// ## Examples
-/// 
+///
 /// ```
 /// use ontolius::prelude::*;
-/// 
+///
 /// let seizure = TermId::from(("HP", "0001250"));
 /// assert_eq!(&seizure, ("HP", "0001250"));
-/// 
+///
 /// let adenocarcinoma = TermId::from(("NCIT", "C2852"));
 /// assert_eq!(&adenocarcinoma, ("NCIT", "C2852"));
 /// ```
@@ -284,7 +285,11 @@ impl From<(&str, &str)> for InnerTermId {
         match (p, a) {
             (Ok(prefix), Ok(id)) => {
                 // Prefix is known
-                InnerTermId::Known(prefix, id, id_len.expect("ID should not be longer than 255 chars!"))
+                InnerTermId::Known(
+                    prefix,
+                    id,
+                    id_len.expect("ID should not be longer than 255 chars!"),
+                )
             }
             _ => {
                 //
@@ -486,7 +491,6 @@ mod test_equalities {
             } else {
                 assert_ne!(term_id, $other);
             }
-            
         };
     }
 
@@ -496,7 +500,7 @@ mod test_equalities {
         term_ids_partial_eq!("HP:0001250", ("HP", "0001250"), true);
         term_ids_partial_eq!("NCIT:C2852", ("NCIT", "C2852"), true);
         term_ids_partial_eq!("HP:0000000", ("HP", "0000000"), true);
-        
+
         term_ids_partial_eq!("HP:0001250", ("MP", "0001250"), false);
         term_ids_partial_eq!("HP:1234567", ("HP", "0000000"), false);
         term_ids_partial_eq!("NCIT:C2852", ("HP", "0001250"), false);

--- a/src/base/term.rs
+++ b/src/base/term.rs
@@ -1,7 +1,7 @@
 use crate::base::{Identified, TermId};
 use std::fmt::Debug;
 
-/// Some terms have alternate identifiers, 
+/// Some terms have alternate identifiers,
 /// e.g. the identifiers used to refer to the term in the past.
 pub trait AltTermIdAware {
     type TermIdIter<'a>: Iterator<Item = &'a TermId>

--- a/src/base/term.rs
+++ b/src/base/term.rs
@@ -1,5 +1,4 @@
 use crate::base::{Identified, TermId};
-use std::fmt::Debug;
 
 /// Some terms have alternate identifiers,
 /// e.g. the identifiers used to refer to the term in the past.
@@ -19,7 +18,7 @@ pub trait AltTermIdAware {
 ///
 /// On top of inherited traits, such as [`Identified`], [`AltTermIdAware`], and others,
 /// the term must have a name and it is either current or obsolete.
-pub trait MinimalTerm: Identified + AltTermIdAware + Clone + Debug + PartialEq {
+pub trait MinimalTerm: Identified + AltTermIdAware {
     /// Get the name of the term, e.g. `Seizure`` for [Seizure](https://hpo.jax.org/browse/term/HP:0001250).
     fn name(&self) -> &str;
 

--- a/src/hierarchy/edge.rs
+++ b/src/hierarchy/edge.rs
@@ -1,8 +1,6 @@
 use std::fmt::Debug;
 use std::hash::Hash;
 
-use super::HierarchyIdx;
-
 /// A relationship between the ontology concepts.
 ///
 /// At this time, we only support `is_a` relationship.
@@ -28,8 +26,6 @@ pub struct GraphEdge<I> {
 }
 
 impl<I> From<(I, Relationship, I)> for GraphEdge<I>
-where
-    I: HierarchyIdx,
 {
     fn from(value: (I, Relationship, I)) -> Self {
         Self {

--- a/src/hierarchy/mod.rs
+++ b/src/hierarchy/mod.rs
@@ -12,10 +12,9 @@ mod edge;
 pub use edge::{GraphEdge, Relationship};
 
 /// Trait for types that can provide the child nodes of an ontology node.
-/// 
+///
 /// [`I`] - Ontology node indexer.
-pub trait ChildNodes<I> {   
-
+pub trait ChildNodes<I> {
     /// Returns an iterator of all nodes which are children of `node`.
     #[deprecated(since = "0.1.3", note = "Use `iter_children_of` instead")]
     fn children_of<'a>(&'a self, node: &I) -> impl Iterator<Item = &'a I>
@@ -68,160 +67,169 @@ pub trait ChildNodes<I> {
 }
 
 /// Trait for types that can provide the descendant nodes of an ontology node.
-pub trait DescendantNodes {
-    // TODO: DescendantNodes should be generic over `I`, see `ChildNodes`
+///
+/// [`I`] - Ontology node indexer.
+pub trait DescendantNodes<I> {
     // Type used to index the ontology nodes.
-    type I;
 
     /// Returns an iterator of all nodes which are descendants of `node`.
     #[deprecated(since = "0.1.3", note = "Use `iter_descendants_of` instead")]
-    fn descendants_of(&self, node: &Self::I) -> impl Iterator<Item = &Self::I> {
+    fn descendants_of<'a>(&'a self, node: &I) -> impl Iterator<Item = &'a I>
+    where
+        I: 'a,
+    {
         self.iter_descendants_of(node)
     }
 
     /// Returns an iterator of all nodes which are descendants of `node`.
-    fn iter_descendants_of(&self, node: &Self::I) -> impl Iterator<Item = &Self::I>;
+    fn iter_descendants_of<'a>(&'a self, node: &I) -> impl Iterator<Item = &'a I>
+    where
+        I: 'a;
 
     /// Get an iterator for iterating over a node followed by all its descendants.
-    fn iter_node_and_descendants_of<'a>(
-        &'a self,
-        node: &'a Self::I,
-    ) -> impl Iterator<Item = &'a Self::I> {
+    fn iter_node_and_descendants_of<'a>(&'a self, node: &'a I) -> impl Iterator<Item = &'a I> {
         std::iter::once(node).chain(self.iter_descendants_of(node))
     }
 
     /// Augment the collection with *descendants* of the source `node`.
-    fn augment_with_descendants<'a, T>(&'a self, node: &Self::I, collection: &mut T)
+    fn augment_with_descendants<T>(&self, node: &I, collection: &mut T)
     where
-        T: Extend<&'a Self::I>,
-        Self: 'a,
+        I: Clone,
+        T: Extend<I>,
     {
-        collection.extend(self.iter_descendants_of(node))
+        collection.extend(self.iter_descendants_of(node).cloned())
     }
 
     /// Augment the collection with the source `node` and its *descendants*.
-    fn augment_with_source_and_descendants<'a, T>(&'a self, node: &'a Self::I, collection: &mut T)
+    fn augment_with_source_and_descendants<'a, T>(&self, node: &I, collection: &mut T)
     where
-        T: Extend<&'a Self::I>,
-        Self: 'a,
+        I: Clone,
+        T: Extend<I>,
     {
-        collection.extend(self.iter_descendants_of(node));
+        collection.extend(self.iter_descendants_of(node).cloned());
     }
 }
 
 /// Trait for types that can provide the parent nodes of an ontology node.
-pub trait ParentNodes {
-    // Type used to index the ontology nodes.
-    type I: Eq;
-
+///
+/// [`I`] - Ontology node indexer.
+pub trait ParentNodes<I> {
     /// Returns an iterator of all nodes which are parents of `node`.
     #[deprecated(since = "0.1.3", note = "Use `iter_parents_of` instead")]
-    fn parents_of(&self, node: &Self::I) -> impl Iterator<Item = &Self::I> {
+    fn parents_of<'a>(&'a self, node: &I) -> impl Iterator<Item = &'a I>
+    where
+        I: 'a,
+    {
         self.iter_parents_of(node)
     }
 
     /// Returns an iterator of all nodes which are parents of `node`.
-    fn iter_parents_of(&self, node: &Self::I) -> impl Iterator<Item = &Self::I>;
+    fn iter_parents_of<'a>(&'a self, node: &I) -> impl Iterator<Item = &'a I>
+    where
+        I: 'a;
 
     /// Test if `sub` is parent of the `obj` node.
-    fn is_parent_of(&self, sub: &Self::I, obj: &Self::I) -> bool {
+    fn is_parent_of(&self, sub: &I, obj: &I) -> bool
+    where
+        I: PartialEq,
+    {
         self.iter_parents_of(obj).any(|parent| *parent == *sub)
     }
 
     /// Get an iterator for iterating over a node followed by all its parents.
-    fn iter_node_and_parents_of<'a>(
-        &'a self,
-        node: &'a Self::I,
-    ) -> impl Iterator<Item = &'a Self::I> {
+    fn iter_node_and_parents_of<'a>(&'a self, node: &'a I) -> impl Iterator<Item = &'a I> {
         std::iter::once(node).chain(self.iter_parents_of(node))
     }
 
     /// Augment the collection with *parents* of the source `node`.
-    fn augment_with_parents<'a, T>(&'a self, node: &Self::I, collection: &mut T)
+    fn augment_with_parents<T>(&self, node: &I, collection: &mut T)
     where
-        T: Extend<&'a Self::I>,
-        Self: 'a,
+        I: Clone,
+        T: Extend<I>,
     {
-        collection.extend(self.iter_parents_of(node))
+        collection.extend(self.iter_parents_of(node).cloned())
     }
 
     /// Augment the collection with the source `node` and its *parents*.
-    fn augment_with_source_and_parents<'a, T>(&'a self, node: &'a Self::I, collection: &mut T)
+    fn augment_with_source_and_parents<T>(&self, node: &I, collection: &mut T)
     where
-        T: Extend<&'a Self::I>,
-        Self: 'a,
+        I: Clone,
+        T: Extend<I>,
     {
-        collection.extend(self.iter_node_and_parents_of(node));
+        collection.extend(self.iter_node_and_parents_of(node).cloned());
     }
 }
 
 /// Trait for types that can provide the ancestor nodes of an ontology node.
-pub trait AncestorNodes {
-    // Type used to index the ontology nodes.
-    type I: Eq;
-
+///
+/// [`I`] - Ontology node indexer.
+pub trait AncestorNodes<I> {
     /// Returns an iterator of all nodes which are ancestors of `node`.
     #[deprecated(since = "0.1.3", note = "Use `iter_ancestors_of` instead")]
-    fn ancestors_of(&self, node: &Self::I) -> impl Iterator<Item = &Self::I> {
+    fn ancestors_of<'a>(&'a self, node: &I) -> impl Iterator<Item = &'a I>
+    where
+        I: 'a,
+    {
         self.iter_ancestors_of(node)
     }
 
     /// Returns an iterator of all nodes which are ancestors of `node`.
-    fn iter_ancestors_of(&self, node: &Self::I) -> impl Iterator<Item = &Self::I>;
+    fn iter_ancestors_of<'a>(&'a self, node: &I) -> impl Iterator<Item = &'a I>
+    where
+        I: 'a;
 
     /// Test if `sub` is an ancestor of `obj`.
-    fn is_ancestor_of(&self, sub: &Self::I, obj: &Self::I) -> bool {
+    fn is_ancestor_of(&self, sub: &I, obj: &I) -> bool
+    where
+        I: PartialEq,
+    {
         self.iter_ancestors_of(obj).any(|anc| *anc == *sub)
     }
 
     /// Test if `sub`` is a descendant of `obj`.
-    fn is_descendant_of(&self, sub: &Self::I, obj: &Self::I) -> bool {
+    fn is_descendant_of(&self, sub: &I, obj: &I) -> bool
+    where
+        I: PartialEq,
+    {
         self.iter_ancestors_of(sub).any(|parent| *parent == *obj)
     }
 
     /// Get an iterator for iterating over a node followed by all its ancestors.
-    fn iter_node_and_ancestors_of<'a>(
-        &'a self,
-        node: &'a Self::I,
-    ) -> impl Iterator<Item = &'a Self::I> {
+    fn iter_node_and_ancestors_of<'a>(&'a self, node: &'a I) -> impl Iterator<Item = &'a I> {
         std::iter::once(node).chain(self.iter_ancestors_of(node))
     }
 
     /// Augment the collection with *ancestors* of the source `node`.
-    fn augment_with_ancestors<'a, T>(&'a self, node: &Self::I, collection: &mut T)
+    fn augment_with_ancestors<T>(&self, node: &I, collection: &mut T)
     where
-        T: Extend<&'a Self::I>,
-        Self: 'a,
+        I: Clone,
+        T: Extend<I>,
     {
-        collection.extend(self.iter_ancestors_of(node))
+        collection.extend(self.iter_ancestors_of(node).cloned())
     }
 
     /// Augment the collection with the source `node` and its *ancestors*.
-    fn augment_with_node_and_ancestors<'a, T>(&'a self, node: &'a Self::I, collection: &mut T)
+    fn augment_with_node_and_ancestors<T>(&self, node: &I, collection: &mut T)
     where
-        T: Extend<&'a Self::I>,
-        Self: 'a,
+        I: Clone,
+        T: Extend<I>,
     {
-        collection.extend(self.iter_node_and_ancestors_of(node));
+        collection.extend(self.iter_node_and_ancestors_of(node).cloned());
     }
 }
 
 /// Trait for types that support all basic ontology hierarchy operations,
 /// such as getting the parents, ancestors, children and descendants
 /// of an ontology node.
-pub trait OntologyHierarchy:
-    ChildNodes<Self::HI>
-    + DescendantNodes<I = Self::HI>
-    + ParentNodes<I = Self::HI>
-    + AncestorNodes<I = Self::HI>
+/// 
+/// [`I`] - Ontology node indexer.
+pub trait OntologyHierarchy<I>:
+    ChildNodes<I> + DescendantNodes<I> + ParentNodes<I> + AncestorNodes<I>
 {
-    // Type used to index the ontology nodes.
-    type HI: Eq;
-
     /// Get index of the root element.
-    fn root(&self) -> &Self::HI;
+    fn root(&self) -> &I;
 
-    fn subhierarchy(&self, subroot_idx: &Self::HI) -> Self;
+    fn subhierarchy(&self, subroot_idx: &I) -> Self;
 }
 
 /// The implementors can be used to index the [`super::OntologyHierarchy`].

--- a/src/hierarchy/mod.rs
+++ b/src/hierarchy/mod.rs
@@ -101,7 +101,7 @@ pub trait DescendantNodes<I> {
     }
 
     /// Augment the collection with the source `node` and its *descendants*.
-    fn augment_with_source_and_descendants<'a, T>(&self, node: &I, collection: &mut T)
+    fn augment_with_source_and_descendants<T>(&self, node: &I, collection: &mut T)
     where
         I: Clone,
         T: Extend<I>,
@@ -221,7 +221,7 @@ pub trait AncestorNodes<I> {
 /// Trait for types that support all basic ontology hierarchy operations,
 /// such as getting the parents, ancestors, children and descendants
 /// of an ontology node.
-/// 
+///
 /// [`I`] - Ontology node index.
 pub trait OntologyHierarchy<I>:
     ChildNodes<I> + DescendantNodes<I> + ParentNodes<I> + AncestorNodes<I>

--- a/src/hierarchy/mod.rs
+++ b/src/hierarchy/mod.rs
@@ -13,7 +13,7 @@ pub use edge::{GraphEdge, Relationship};
 
 /// Trait for types that can provide the child nodes of an ontology node.
 ///
-/// [`I`] - Ontology node index.
+/// * `I` - ontology node index.
 pub trait ChildNodes<I> {
     /// Returns an iterator of all nodes which are children of `node`.
     #[deprecated(since = "0.1.3", note = "Use `iter_children_of` instead")]
@@ -68,7 +68,7 @@ pub trait ChildNodes<I> {
 
 /// Trait for types that can provide the descendant nodes of an ontology node.
 ///
-/// [`I`] - Ontology node index.
+/// * `I` - ontology node index.
 pub trait DescendantNodes<I> {
     // Type used to index the ontology nodes.
 
@@ -112,7 +112,7 @@ pub trait DescendantNodes<I> {
 
 /// Trait for types that can provide the parent nodes of an ontology node.
 ///
-/// [`I`] - Ontology node index.
+/// * `I` - ontology node index.
 pub trait ParentNodes<I> {
     /// Returns an iterator of all nodes which are parents of `node`.
     #[deprecated(since = "0.1.3", note = "Use `iter_parents_of` instead")]
@@ -162,7 +162,7 @@ pub trait ParentNodes<I> {
 
 /// Trait for types that can provide the ancestor nodes of an ontology node.
 ///
-/// [`I`] - Ontology node index.
+/// * `I` - ontology node index.
 pub trait AncestorNodes<I> {
     /// Returns an iterator of all nodes which are ancestors of `node`.
     #[deprecated(since = "0.1.3", note = "Use `iter_ancestors_of` instead")]
@@ -222,7 +222,7 @@ pub trait AncestorNodes<I> {
 /// such as getting the parents, ancestors, children and descendants
 /// of an ontology node.
 ///
-/// [`I`] - Ontology node index.
+/// * `I` - ontology node index.
 pub trait OntologyHierarchy<I>:
     ChildNodes<I> + DescendantNodes<I> + ParentNodes<I> + AncestorNodes<I>
 {
@@ -232,7 +232,7 @@ pub trait OntologyHierarchy<I>:
     fn subhierarchy(&self, subroot_idx: &I) -> Self;
 }
 
-/// The implementors can be used to index the [`super::OntologyHierarchy`].
+/// The implementors can be used to index the [`OntologyHierarchy`].
 pub trait HierarchyIdx: Copy + Eq {
     fn new(idx: usize) -> Self;
 }

--- a/src/hierarchy/mod.rs
+++ b/src/hierarchy/mod.rs
@@ -13,7 +13,7 @@ pub use edge::{GraphEdge, Relationship};
 
 /// Trait for types that can provide the child nodes of an ontology node.
 ///
-/// [`I`] - Ontology node indexer.
+/// [`I`] - Ontology node index.
 pub trait ChildNodes<I> {
     /// Returns an iterator of all nodes which are children of `node`.
     #[deprecated(since = "0.1.3", note = "Use `iter_children_of` instead")]
@@ -68,7 +68,7 @@ pub trait ChildNodes<I> {
 
 /// Trait for types that can provide the descendant nodes of an ontology node.
 ///
-/// [`I`] - Ontology node indexer.
+/// [`I`] - Ontology node index.
 pub trait DescendantNodes<I> {
     // Type used to index the ontology nodes.
 
@@ -112,7 +112,7 @@ pub trait DescendantNodes<I> {
 
 /// Trait for types that can provide the parent nodes of an ontology node.
 ///
-/// [`I`] - Ontology node indexer.
+/// [`I`] - Ontology node index.
 pub trait ParentNodes<I> {
     /// Returns an iterator of all nodes which are parents of `node`.
     #[deprecated(since = "0.1.3", note = "Use `iter_parents_of` instead")]
@@ -162,7 +162,7 @@ pub trait ParentNodes<I> {
 
 /// Trait for types that can provide the ancestor nodes of an ontology node.
 ///
-/// [`I`] - Ontology node indexer.
+/// [`I`] - Ontology node index.
 pub trait AncestorNodes<I> {
     /// Returns an iterator of all nodes which are ancestors of `node`.
     #[deprecated(since = "0.1.3", note = "Use `iter_ancestors_of` instead")]
@@ -222,7 +222,7 @@ pub trait AncestorNodes<I> {
 /// such as getting the parents, ancestors, children and descendants
 /// of an ontology node.
 /// 
-/// [`I`] - Ontology node indexer.
+/// [`I`] - Ontology node index.
 pub trait OntologyHierarchy<I>:
     ChildNodes<I> + DescendantNodes<I> + ParentNodes<I> + AncestorNodes<I>
 {

--- a/src/hierarchy/mod.rs
+++ b/src/hierarchy/mod.rs
@@ -253,9 +253,3 @@ impl_idx!(u16);
 impl_idx!(u32);
 impl_idx!(u64);
 impl_idx!(usize);
-
-impl_idx!(i8);
-impl_idx!(i16);
-impl_idx!(i32);
-impl_idx!(i64);
-impl_idx!(isize);

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -65,7 +65,7 @@ where
     where
         P: AsRef<Path>,
         O: TryFrom<OntologyData<Parser::HI, Parser::T>, Error = anyhow::Error>
-            + Ontology<Idx = Parser::HI, T = Parser::T>,
+            + Ontology<Parser::HI, Parser::T>,
     {
         let path = path.as_ref();
         let file = File::open(path).with_context(|| format!("Opening file at {:?}", path))?;
@@ -89,7 +89,7 @@ where
     where
         R: Read,
         O: TryFrom<OntologyData<Parser::HI, Parser::T>, Error = anyhow::Error>
-            + Ontology<Idx = Parser::HI, T = Parser::T>,
+            + Ontology<Parser::HI, Parser::T>,
     {
         self.load_from_buf_read(BufReader::new(read))
     }
@@ -99,7 +99,7 @@ where
     where
         R: BufRead,
         O: TryFrom<OntologyData<Parser::HI, Parser::T>, Error = anyhow::Error>
-            + Ontology<Idx = Parser::HI, T = Parser::T>,
+            + Ontology<Parser::HI, Parser::T>,
     {
         let data = self.parser.load_from_buf_read(read)?;
         O::try_from(data)

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -32,11 +32,11 @@ impl<I, T> From<(Vec<T>, Vec<GraphEdge<I>>, HashMap<String, String>)> for Ontolo
 
 /// Ontology data parser can read [`OntologyData`] from some input
 pub trait OntologyDataParser {
-    type HI;
+    type I;
     type T;
 
     /// Load ontology data from the buffered reader.
-    fn load_from_buf_read<R>(&self, read: R) -> Result<OntologyData<Self::HI, Self::T>>
+    fn load_from_buf_read<R>(&self, read: R) -> Result<OntologyData<Self::I, Self::T>>
     where
         R: BufRead;
 }
@@ -64,8 +64,8 @@ where
     pub fn load_from_path<O, P>(&self, path: P) -> Result<O>
     where
         P: AsRef<Path>,
-        O: TryFrom<OntologyData<Parser::HI, Parser::T>, Error = anyhow::Error>
-            + Ontology<Parser::HI, Parser::T>,
+        O: TryFrom<OntologyData<Parser::I, Parser::T>, Error = anyhow::Error>
+            + Ontology<Parser::I, Parser::T>,
     {
         let path = path.as_ref();
         let file = File::open(path).with_context(|| format!("Opening file at {:?}", path))?;
@@ -88,8 +88,8 @@ where
     pub fn load_from_read<R, O>(&self, read: R) -> Result<O>
     where
         R: Read,
-        O: TryFrom<OntologyData<Parser::HI, Parser::T>, Error = anyhow::Error>
-            + Ontology<Parser::HI, Parser::T>,
+        O: TryFrom<OntologyData<Parser::I, Parser::T>, Error = anyhow::Error>
+            + Ontology<Parser::I, Parser::T>,
     {
         self.load_from_buf_read(BufReader::new(read))
     }
@@ -98,8 +98,8 @@ where
     pub fn load_from_buf_read<R, O>(&self, read: R) -> Result<O>
     where
         R: BufRead,
-        O: TryFrom<OntologyData<Parser::HI, Parser::T>, Error = anyhow::Error>
-            + Ontology<Parser::HI, Parser::T>,
+        O: TryFrom<OntologyData<Parser::I, Parser::T>, Error = anyhow::Error>
+            + Ontology<Parser::I, Parser::T>,
     {
         let data = self.parser.load_from_buf_read(read)?;
         O::try_from(data)

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -14,14 +14,14 @@ use std::{
 
 use crate::{hierarchy::GraphEdge, prelude::Ontology};
 
-pub struct OntologyData<HI, T> {
+pub struct OntologyData<I, T> {
     pub terms: Vec<T>,
-    pub edges: Vec<GraphEdge<HI>>,
+    pub edges: Vec<GraphEdge<I>>,
     pub metadata: HashMap<String, String>,
 }
 
-impl<HI, T> From<(Vec<T>, Vec<GraphEdge<HI>>, HashMap<String, String>)> for OntologyData<HI, T> {
-    fn from(value: (Vec<T>, Vec<GraphEdge<HI>>, HashMap<String, String>)) -> Self {
+impl<I, T> From<(Vec<T>, Vec<GraphEdge<I>>, HashMap<String, String>)> for OntologyData<I, T> {
+    fn from(value: (Vec<T>, Vec<GraphEdge<I>>, HashMap<String, String>)) -> Self {
         Self {
             terms: value.0,
             edges: value.1,

--- a/src/ontology/csr/hierarchy.rs
+++ b/src/ontology/csr/hierarchy.rs
@@ -96,24 +96,26 @@ where
     }
 }
 
-impl<I> ParentNodes for CsrOntologyHierarchy<I>
+impl<I> ParentNodes<I> for CsrOntologyHierarchy<I>
 where
     I: CsrIdx + HierarchyIdx + Hash,
 {
-    type I = I;
-
-    fn iter_parents_of(&self, node: &I) -> impl Iterator<Item = &Self::I> {
+    fn iter_parents_of<'a>(&'a self, node: &I) -> impl Iterator<Item = &'a I>
+    where
+        I: 'a,
+    {
         self.adjacency_matrix.out_neighbors(*node)
     }
 }
 
-impl<I> DescendantNodes for CsrOntologyHierarchy<I>
+impl<I> DescendantNodes<I> for CsrOntologyHierarchy<I>
 where
     I: CsrIdx + HierarchyIdx + Hash,
 {
-    type I = I;
-
-    fn iter_descendants_of(&self, node: &I) -> impl Iterator<Item = &Self::I> {
+    fn iter_descendants_of<'a>(&'a self, node: &I) -> impl Iterator<Item = &'a I>
+    where
+        I: 'a,
+    {
         DescendantsIter {
             adjacency_matrix: &self.adjacency_matrix,
             seen: HashSet::new(),
@@ -149,13 +151,14 @@ where
     }
 }
 
-impl<I> AncestorNodes for CsrOntologyHierarchy<I>
+impl<I> AncestorNodes<I> for CsrOntologyHierarchy<I>
 where
     I: CsrIdx + HierarchyIdx + Hash,
 {
-    type I = I;
-
-    fn iter_ancestors_of(&self, node: &I) -> impl Iterator<Item = &Self::I> {
+    fn iter_ancestors_of<'a>(&'a self, node: &I) -> impl Iterator<Item = &I>
+    where
+        I: 'a,
+    {
         AncestorIter {
             adjacency_matrix: &self.adjacency_matrix,
             seen: HashSet::new(),
@@ -191,12 +194,10 @@ where
     }
 }
 
-impl<I> OntologyHierarchy for CsrOntologyHierarchy<I>
+impl<I> OntologyHierarchy<I> for CsrOntologyHierarchy<I>
 where
     I: CsrIdx + HierarchyIdx + Hash,
 {
-    type HI = I;
-
     /// Get index of the ontology root.
     fn root(&self) -> &I {
         &self.root_idx
@@ -240,7 +241,7 @@ mod test_hierarchy {
 
     fn check_members<'a, O, F, I>(hierarchy: &'a O, func: F, src: &'a u16, expected: &[u16])
     where
-        O: OntologyHierarchy<HI = u16>,
+        O: OntologyHierarchy<u16>,
         F: FnOnce(&'a O, &'a u16) -> I,
         I: Iterator<Item = &'a u16>,
     {

--- a/src/ontology/csr/hierarchy.rs
+++ b/src/ontology/csr/hierarchy.rs
@@ -2,8 +2,8 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::hash::Hash;
 
 use crate::hierarchy::{
-    AncestorNodes, ChildNodes, DescendantNodes, GraphEdge, OntologyHierarchy,
-    ParentNodes, Relationship,
+    AncestorNodes, ChildNodes, DescendantNodes, GraphEdge, OntologyHierarchy, ParentNodes,
+    Relationship,
 };
 
 use anyhow::{bail, Context, Error, Result};

--- a/src/ontology/csr/hierarchy.rs
+++ b/src/ontology/csr/hierarchy.rs
@@ -84,13 +84,14 @@ where
     })
 }
 
-impl<I> ChildNodes for CsrOntologyHierarchy<I>
+impl<I> ChildNodes<I> for CsrOntologyHierarchy<I>
 where
     I: CsrIdx + HierarchyIdx,
 {
-    type I = I;
-
-    fn iter_children_of(&self, node: &I) -> impl Iterator<Item = &Self::I> {
+    fn iter_children_of<'a>(&'a self, node: &I) -> impl Iterator<Item = &'a I>
+    where
+        I: 'a,
+    {
         self.adjacency_matrix.in_neighbors(*node)
     }
 }

--- a/src/ontology/csr/hierarchy.rs
+++ b/src/ontology/csr/hierarchy.rs
@@ -44,7 +44,7 @@ where
     }
 }
 
-fn find_root_idx<'a, I>(graph_edges: &'a [GraphEdge<I>]) -> Result<&'a I>
+fn find_root_idx<I>(graph_edges: &[GraphEdge<I>]) -> Result<&I>
 where
     I: Hash + Eq,
 {
@@ -157,7 +157,7 @@ impl<I> AncestorNodes<I> for CsrOntologyHierarchy<I>
 where
     I: CsrIdx + Hash,
 {
-    fn iter_ancestors_of<'a>(&'a self, node: &I) -> impl Iterator<Item = &I>
+    fn iter_ancestors_of<'a>(&'a self, node: &I) -> impl Iterator<Item = &'a I>
     where
         I: 'a,
     {

--- a/src/ontology/csr/hierarchy.rs
+++ b/src/ontology/csr/hierarchy.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::hash::Hash;
 
 use crate::hierarchy::{
-    AncestorNodes, ChildNodes, DescendantNodes, GraphEdge, HierarchyIdx, OntologyHierarchy,
+    AncestorNodes, ChildNodes, DescendantNodes, GraphEdge, OntologyHierarchy,
     ParentNodes, Relationship,
 };
 
@@ -23,7 +23,7 @@ where
 
 impl<I> TryFrom<&[GraphEdge<I>]> for CsrOntologyHierarchy<I>
 where
-    I: CsrIdx + HierarchyIdx + Hash,
+    I: CsrIdx + Hash,
 {
     type Error = Error;
     // TODO: we do not need a slice, all we need is a type that can be iterated over multiple times!
@@ -44,7 +44,7 @@ where
 
 fn find_root_idx<I>(graph_edges: &[GraphEdge<I>]) -> Result<I>
 where
-    I: Hash + HierarchyIdx + Eq,
+    I: Hash + Copy + Eq,
 {
     let mut root_candidate_set = HashSet::new();
     let mut remove_mark_set = HashSet::new();
@@ -86,7 +86,7 @@ where
 
 impl<I> ChildNodes<I> for CsrOntologyHierarchy<I>
 where
-    I: CsrIdx + HierarchyIdx,
+    I: CsrIdx,
 {
     fn iter_children_of<'a>(&'a self, node: &I) -> impl Iterator<Item = &'a I>
     where
@@ -98,7 +98,7 @@ where
 
 impl<I> ParentNodes<I> for CsrOntologyHierarchy<I>
 where
-    I: CsrIdx + HierarchyIdx + Hash,
+    I: CsrIdx,
 {
     fn iter_parents_of<'a>(&'a self, node: &I) -> impl Iterator<Item = &'a I>
     where
@@ -110,7 +110,7 @@ where
 
 impl<I> DescendantNodes<I> for CsrOntologyHierarchy<I>
 where
-    I: CsrIdx + HierarchyIdx + Hash,
+    I: CsrIdx + Hash,
 {
     fn iter_descendants_of<'a>(&'a self, node: &I) -> impl Iterator<Item = &'a I>
     where
@@ -126,7 +126,7 @@ where
 
 pub struct DescendantsIter<'a, I>
 where
-    I: CsrIdx + HierarchyIdx + Hash,
+    I: CsrIdx,
 {
     adjacency_matrix: &'a DirectedCsrGraph<I>,
     seen: HashSet<&'a I>,
@@ -135,7 +135,7 @@ where
 
 impl<'a, I> Iterator for DescendantsIter<'a, I>
 where
-    I: CsrIdx + HierarchyIdx + Hash,
+    I: CsrIdx + Hash,
 {
     type Item = &'a I;
 
@@ -153,7 +153,7 @@ where
 
 impl<I> AncestorNodes<I> for CsrOntologyHierarchy<I>
 where
-    I: CsrIdx + HierarchyIdx + Hash,
+    I: CsrIdx + Hash,
 {
     fn iter_ancestors_of<'a>(&'a self, node: &I) -> impl Iterator<Item = &I>
     where
@@ -169,7 +169,7 @@ where
 
 pub struct AncestorIter<'a, I>
 where
-    I: CsrIdx + HierarchyIdx + Hash,
+    I: CsrIdx,
 {
     adjacency_matrix: &'a DirectedCsrGraph<I>,
     seen: HashSet<&'a I>,
@@ -178,7 +178,7 @@ where
 
 impl<'a, I> Iterator for AncestorIter<'a, I>
 where
-    I: CsrIdx + HierarchyIdx + Hash,
+    I: CsrIdx + Hash,
 {
     type Item = &'a I;
 
@@ -196,7 +196,7 @@ where
 
 impl<I> OntologyHierarchy<I> for CsrOntologyHierarchy<I>
 where
-    I: CsrIdx + HierarchyIdx + Hash,
+    I: CsrIdx + Hash,
 {
     /// Get index of the ontology root.
     fn root(&self) -> &I {

--- a/src/ontology/csr/mod.rs
+++ b/src/ontology/csr/mod.rs
@@ -34,4 +34,9 @@ mod hierarchy;
 mod ontology;
 
 pub use hierarchy::CsrOntologyHierarchy;
-pub use ontology::{CsrOntology, MinimalCsrOntology};
+pub use ontology::CsrOntology;
+
+use crate::base::term::simple::SimpleMinimalTerm;
+
+/// A [`CsrOntology`] with [`usize`] used as node indexer and [`SimpleMinimalTerm`] as the term.
+pub type MinimalCsrOntology = CsrOntology<usize, SimpleMinimalTerm>;

--- a/src/ontology/csr/mod.rs
+++ b/src/ontology/csr/mod.rs
@@ -1,33 +1,33 @@
-//! Module with `Ontology` backed by a term array 
+//! Module with `Ontology` backed by a term array
 //! and a CSR adjacency matrix.
-//! 
-//! # Example 
-//! 
+//!
+//! # Example
+//!
 //! ```rust
 //! use ontolius::prelude::*;
 //! use ontolius::ontology::csr::CsrOntology;
-//! 
+//!
 //! // Configure the ontology loader to parse Obographs JSON file.
 //! let loader = OntologyLoaderBuilder::new()
 //!                .obographs_parser()
 //!                .build();
-//! 
+//!
 //! // Load a small Obographs JSON file into `CsrOntology`.
 //! // Use `usize` as ontology graph indices.
 //! let path = "resources/hp.small.json.gz";
 //! let ontology: CsrOntology<usize, _> = loader.load_from_path(path)
 //!                                         .expect("Obographs JSON should be parsable");
-//! 
+//!
 //! // or do the same using the `MinimalCsrOntology` alias to save some typing:
 //! use ontolius::ontology::csr::MinimalCsrOntology;
-//! 
+//!
 //! let ontology: MinimalCsrOntology = loader.load_from_path(path)
 //!                                         .expect("Obographs JSON should be parsable");
-//! 
+//!
 //! // Check the number of primary terms
 //! assert_eq!(ontology.len(), 614);
 //! ```
-//! 
+//!
 //! Check the [`crate::ontology::Ontology`] documentation for more info
 //! regarding the supported functionality.
 mod hierarchy;

--- a/src/ontology/csr/ontology.rs
+++ b/src/ontology/csr/ontology.rs
@@ -4,40 +4,37 @@ use std::{collections::HashMap, iter::once};
 
 use graph_builder::index::Idx as CsrIdx;
 
-use crate::base::term::simple::SimpleMinimalTerm;
-use crate::base::{term::MinimalTerm, Identified, TermId};
+use crate::base::{Identified, TermId};
 use crate::hierarchy::HierarchyIdx;
 use crate::io::OntologyData;
 use crate::ontology::{HierarchyAware, MetadataAware, Ontology, OntologyIdx, TermAware, TermIdx};
+use crate::prelude::AltTermIdAware;
 use anyhow::Error;
 
 use super::hierarchy::CsrOntologyHierarchy;
 
-/// A [`CsrOntology`] with [`usize`] used as node indexer and [`SimpleMinimalTerm`] as the term.
-pub type MinimalCsrOntology = CsrOntology<usize, SimpleMinimalTerm>;
-
 /// An example implementation of [`Ontology`]
 /// backed by a ontology graph implemented
 /// with a CSR adjacency matrix.
-pub struct CsrOntology<HI, T>
+pub struct CsrOntology<I, T>
 where
-    HI: CsrIdx,
+    I: CsrIdx,
 {
     terms: Box<[T]>,
-    term_id_to_idx: HashMap<TermId, HI>,
-    hierarchy: CsrOntologyHierarchy<HI>,
+    term_id_to_idx: HashMap<TermId, I>,
+    hierarchy: CsrOntologyHierarchy<I>,
     metadata: HashMap<String, String>,
 }
 
 /// `CsrOntology` can be built from [`OntologyData`].
-impl<HI, T> TryFrom<OntologyData<HI, T>> for CsrOntology<HI, T>
+impl<I, T> TryFrom<OntologyData<I, T>> for CsrOntology<I, T>
 where
-    HI: HierarchyIdx + CsrIdx + Hash,
-    T: MinimalTerm,
+    I: HierarchyIdx + CsrIdx + Hash,
+    T: Identified + AltTermIdAware,
 {
     type Error = Error;
 
-    fn try_from(value: OntologyData<HI, T>) -> Result<Self, Self::Error> {
+    fn try_from(value: OntologyData<I, T>) -> Result<Self, Self::Error> {
         // TODO: I am not sure this is the most efficient way to build the ontology.
         let OntologyData {
             terms,
@@ -70,11 +67,11 @@ where
     }
 }
 
-impl<HI, T> HierarchyAware<HI> for CsrOntology<HI, T>
+impl<I, T> HierarchyAware<I> for CsrOntology<I, T>
 where
-    HI: HierarchyIdx + CsrIdx + Hash,
+    I: HierarchyIdx + CsrIdx + Hash,
 {
-    type Hierarchy = CsrOntologyHierarchy<HI>;
+    type Hierarchy = CsrOntologyHierarchy<I>;
 
     fn hierarchy(&self) -> &Self::Hierarchy {
         &self.hierarchy
@@ -84,7 +81,6 @@ where
 impl<I, T> TermAware<I, T> for CsrOntology<I, T>
 where
     I: CsrIdx + TermIdx,
-    T: MinimalTerm,
 {
     fn iter_terms<'a>(&'a self) -> impl Iterator<Item = &T>
     where
@@ -113,9 +109,9 @@ where
     }
 }
 
-impl<HI, T> MetadataAware for CsrOntology<HI, T>
+impl<I, T> MetadataAware for CsrOntology<I, T>
 where
-    HI: CsrIdx,
+    I: CsrIdx,
 {
     fn version(&self) -> &str {
         self.metadata
@@ -125,12 +121,7 @@ where
     }
 }
 
-impl<I, T> Ontology<I, T> for CsrOntology<I, T>
-where
-    I: OntologyIdx + CsrIdx,
-    T: MinimalTerm,
-{
-}
+impl<I, T> Ontology<I, T> for CsrOntology<I, T> where I: OntologyIdx + CsrIdx {}
 
 #[cfg(test)]
 mod test {

--- a/src/ontology/csr/ontology.rs
+++ b/src/ontology/csr/ontology.rs
@@ -6,10 +6,10 @@ use graph_builder::index::Idx as CsrIdx;
 
 use crate::base::term::simple::SimpleMinimalTerm;
 use crate::base::{term::MinimalTerm, Identified, TermId};
-use anyhow::Error;
 use crate::hierarchy::HierarchyIdx;
 use crate::io::OntologyData;
 use crate::ontology::{HierarchyAware, MetadataAware, Ontology, OntologyIdx, TermAware, TermIdx};
+use anyhow::Error;
 
 use super::hierarchy::CsrOntologyHierarchy;
 
@@ -46,10 +46,7 @@ where
         } = value;
 
         // Only keep the primary terms.
-        let terms: Box<[_]> = terms
-            .into_iter()
-            .collect::<Vec<_>>()
-            .into_boxed_slice();
+        let terms: Box<[_]> = terms.into_iter().collect::<Vec<_>>().into_boxed_slice();
 
         let term_id_to_idx = terms
             .iter()
@@ -84,23 +81,24 @@ where
     }
 }
 
-impl<HI, T> TermAware for CsrOntology<HI, T>
+impl<I, T> TermAware<I, T> for CsrOntology<I, T>
 where
-    HI: TermIdx + CsrIdx,
+    I: TermIdx + CsrIdx,
     T: MinimalTerm,
 {
-    type TI = HI;
-    type Term = T;
 
-    fn iter_terms(&self) -> impl Iterator<Item = &Self::Term> {
+    fn iter_terms<'a>(&'a self) -> impl Iterator<Item = &T>
+    where
+        T: 'a,
+    {
         self.terms.iter()
     }
 
-    fn idx_to_term(&self, idx: &Self::TI) -> Option<&T> {
+    fn idx_to_term(&self, idx: &I) -> Option<&T> {
         self.terms.get(TermIdx::index(idx))
     }
 
-    fn id_to_idx<ID>(&self, id: &ID) -> Option<&Self::TI>
+    fn id_to_idx<ID>(&self, id: &ID) -> Option<&I>
     where
         ID: Identified,
     {

--- a/src/ontology/csr/ontology.rs
+++ b/src/ontology/csr/ontology.rs
@@ -82,7 +82,7 @@ impl<I, T> TermAware<I, T> for CsrOntology<I, T>
 where
     I: CsrIdx + TermIdx,
 {
-    fn iter_terms<'a>(&'a self) -> impl Iterator<Item = &T>
+    fn iter_terms<'a>(&'a self) -> impl Iterator<Item = &'a T>
     where
         T: 'a,
     {

--- a/src/ontology/csr/ontology.rs
+++ b/src/ontology/csr/ontology.rs
@@ -72,7 +72,7 @@ where
 
 impl<HI, T> HierarchyAware<HI> for CsrOntology<HI, T>
 where
-    HI: TermIdx + HierarchyIdx + CsrIdx + Hash,
+    HI: HierarchyIdx + CsrIdx + Hash,
 {
     type Hierarchy = CsrOntologyHierarchy<HI>;
 
@@ -83,7 +83,7 @@ where
 
 impl<I, T> TermAware<I, T> for CsrOntology<I, T>
 where
-    I: TermIdx + CsrIdx,
+    I: CsrIdx + TermIdx,
     T: MinimalTerm,
 {
     fn iter_terms<'a>(&'a self) -> impl Iterator<Item = &T>

--- a/src/ontology/csr/ontology.rs
+++ b/src/ontology/csr/ontology.rs
@@ -86,7 +86,6 @@ where
     I: TermIdx + CsrIdx,
     T: MinimalTerm,
 {
-
     fn iter_terms<'a>(&'a self) -> impl Iterator<Item = &T>
     where
         T: 'a,
@@ -126,13 +125,11 @@ where
     }
 }
 
-impl<I, T> Ontology for CsrOntology<I, T>
+impl<I, T> Ontology<I, T> for CsrOntology<I, T>
 where
     I: OntologyIdx + CsrIdx,
     T: MinimalTerm,
 {
-    type Idx = I;
-    type T = T;
 }
 
 #[cfg(test)]

--- a/src/ontology/csr/ontology.rs
+++ b/src/ontology/csr/ontology.rs
@@ -73,11 +73,10 @@ where
     }
 }
 
-impl<HI, T> HierarchyAware for CsrOntology<HI, T>
+impl<HI, T> HierarchyAware<HI> for CsrOntology<HI, T>
 where
     HI: TermIdx + HierarchyIdx + CsrIdx + Hash,
 {
-    type HI = HI;
     type Hierarchy = CsrOntologyHierarchy<HI>;
 
     fn hierarchy(&self) -> &Self::Hierarchy {

--- a/src/ontology/mod.rs
+++ b/src/ontology/mod.rs
@@ -248,22 +248,20 @@ impl_ontology_idx!(isize);
 /// Last, ontology includes the metadata such as its release version.
 /// See [`MetadataAware`] for more details.
 ///
-pub trait Ontology:
-    TermAware<Self::Idx, Self::T> + HierarchyAware<Self::Idx> + MetadataAware
-{
-    /// The indexer for the terms and ontology graph nodes.
-    type Idx: OntologyIdx;
-    /// The term type.
-    type T: MinimalTerm;
-
+/// [`I`] - The indexer for the terms and ontology graph nodes.
+/// [`T`] - The ontology term type.
+pub trait Ontology<I, T>: TermAware<I, T> + HierarchyAware<I> + MetadataAware {
     /// Get the root term.
-    fn root_term(&self) -> &Self::T {
+    fn root_term(&self) -> &T {
         self.idx_to_term(self.hierarchy().root())
             .expect("Ontology should contain a term for term index")
     }
 
     /// Get the term ID of the root term of the ontology.
-    fn root_term_id(&self) -> &TermId {
+    fn root_term_id<'a>(&'a self) -> &'a TermId
+    where
+        T: Identified + 'a,
+    {
         self.root_term().identifier()
     }
 }

--- a/src/ontology/mod.rs
+++ b/src/ontology/mod.rs
@@ -177,11 +177,11 @@ where
 }
 
 /// The implementors know about the [`OntologyHierarchy`].
-pub trait HierarchyAware {
-    /// The indexer for the graph nodes.
-    type HI;
+/// 
+/// [`I`] - Ontology node indexer.
+pub trait HierarchyAware<I> {
     /// The hierarchy type.
-    type Hierarchy: OntologyHierarchy<HI = Self::HI>;
+    type Hierarchy: OntologyHierarchy<I>;
 
     /// Get the hierarchy.
     fn hierarchy(&self) -> &Self::Hierarchy;
@@ -236,7 +236,7 @@ impl_ontology_idx!(isize);
 /// See [`MetadataAware`] for more details.
 ///
 pub trait Ontology:
-    TermAware<TI = Self::Idx, Term = Self::T> + HierarchyAware<HI = Self::Idx> + MetadataAware
+    TermAware<TI = Self::Idx, Term = Self::T> + HierarchyAware<Self::Idx> + MetadataAware
 {
     /// The indexer for the terms and ontology graph nodes.
     type Idx: OntologyIdx;

--- a/src/ontology/mod.rs
+++ b/src/ontology/mod.rs
@@ -30,12 +30,6 @@ impl_term_idx!(u32);
 impl_term_idx!(u64);
 impl_term_idx!(usize);
 
-impl_term_idx!(i8);
-impl_term_idx!(i16);
-impl_term_idx!(i32);
-impl_term_idx!(i64);
-impl_term_idx!(isize);
-
 /// A trait for types that act as containers of ontology terms.
 ///
 /// The container supports iteration over the terms, retrieval of a term
@@ -229,11 +223,6 @@ impl_ontology_idx!(u32);
 impl_ontology_idx!(u64);
 impl_ontology_idx!(usize);
 
-impl_ontology_idx!(i8);
-impl_ontology_idx!(i16);
-impl_ontology_idx!(i32);
-impl_ontology_idx!(i64);
-impl_ontology_idx!(isize);
 
 /// The specification of an ontology.
 ///

--- a/src/ontology/mod.rs
+++ b/src/ontology/mod.rs
@@ -1,5 +1,6 @@
 //! A module with the ontology parts.
 pub mod csr;
+mod simple;
 
 use std::hash::Hash;
 
@@ -7,7 +8,7 @@ use crate::base::{term::MinimalTerm, Identified, TermId};
 use crate::hierarchy::{HierarchyIdx, OntologyHierarchy};
 use crate::prelude::AltTermIdAware;
 
-/// The implementors can be used to index the [`super::TermAware`].
+/// The implementors can be used to index the [`TermAware`].
 pub trait TermIdx: Copy {
     // Convert the index to `usize` for indexing.
     fn index(&self) -> usize;
@@ -41,27 +42,27 @@ impl_term_idx!(isize);
 /// by its index or by the primary or obsolete [`TermId`],
 /// and several associated convenience methods.
 ///
-/// [`I`] - Ontology node index.
-/// [`T`] - Ontology term.
+/// `I` - Ontology node index.
+/// `T` - Ontology term.
 pub trait TermAware<I, T> {
     /// Get the iterator over the *primary* ontology terms.
     fn iter_terms<'a>(&'a self) -> impl Iterator<Item = &T>
     where
         T: 'a;
 
-    /// Map index to a term [`T`] of the ontology.
+    /// Map index to a term `T` of the ontology.
     ///
     /// Returns `None` if there is no such term for the input `idx` in the ontology.
     fn idx_to_term(&self, idx: &I) -> Option<&T>;
 
-    /// Get the index corresponding to a [`TermAware::Term`] for given ID.
+    /// Get the ontology node index corresponding to the provided `id`.
     fn id_to_idx<ID>(&self, id: &ID) -> Option<&I>
     where
         ID: Identified;
 
-    /// Get term [`T`] for given term ID.
+    /// Get term `T` for given term ID.
     ///
-    /// Returns `None`` if the ID does not correspond to a concept from the ontology.
+    /// Returns `None` if the ID does not correspond to a concept from the ontology.
     fn id_to_term<ID>(&self, id: &ID) -> Option<&T>
     where
         ID: Identified,
@@ -191,7 +192,7 @@ where
 
 /// The implementors know about the [`OntologyHierarchy`].
 ///
-/// [`I`] - Ontology node indexer.
+/// * `I` - ontology node indexer.
 pub trait HierarchyAware<I> {
     /// The hierarchy type.
     type Hierarchy: OntologyHierarchy<I>;
@@ -236,20 +237,19 @@ impl_ontology_idx!(isize);
 
 /// The specification of an ontology.
 ///
-/// The ontology has several functionalities. First, it acts as a container
-/// of ontology terms and supports iterating over all terms/term IDs
+/// An ontology acts as a container of ontology terms and supports iterating over all terms/term IDs
 /// and getting a term either by its index or term ID (including obsolete IDs).
 /// See [`TermAware`] for more details.
 ///
-/// Next, the ontology has the hierarchy - a directed acyclyc graph of term
-/// relations. Currently, only `is_a` relationship is supported.
+/// An ontology also has a hierarchy - a directed acyclic graph of relationships between the terms.
+/// Currently, only `is_a` relationship is supported.
 /// See [`OntologyHierarchy`] for more details.
 ///
-/// Last, ontology includes the metadata such as its release version.
+/// Last, an ontology includes the metadata such as its release version.
 /// See [`MetadataAware`] for more details.
 ///
-/// [`I`] - The indexer for the terms and ontology graph nodes.
-/// [`T`] - The ontology term type.
+/// * `I` - The indexer for the terms and ontology graph nodes.
+/// * `T` - The ontology term type.
 pub trait Ontology<I, T>: TermAware<I, T> + HierarchyAware<I> + MetadataAware {
     /// Get the root term.
     fn root_term(&self) -> &T {

--- a/src/ontology/mod.rs
+++ b/src/ontology/mod.rs
@@ -46,7 +46,7 @@ impl_term_idx!(isize);
 /// `T` - Ontology term.
 pub trait TermAware<I, T> {
     /// Get the iterator over the *primary* ontology terms.
-    fn iter_terms<'a>(&'a self) -> impl Iterator<Item = &T>
+    fn iter_terms<'a>(&'a self) -> impl Iterator<Item = &'a T>
     where
         T: 'a;
 
@@ -113,7 +113,7 @@ pub trait TermAware<I, T> {
     }
 
     /// Iterate over term IDs of *all* terms (primary and obsolete).
-    fn iter_all_term_ids<'a>(&'a self) -> AllTermIdsIter<'_, T>
+    fn iter_all_term_ids<'a>(&'a self) -> AllTermIdsIter<'a, T>
     where
         T: AltTermIdAware,
         I: 'a,

--- a/src/ontology/simple.rs
+++ b/src/ontology/simple.rs
@@ -1,0 +1,117 @@
+use std::{collections::HashMap, iter::once};
+
+use crate::{
+    base::TermId,
+    hierarchy::GraphEdge,
+    io::OntologyData,
+    prelude::{HierarchyIdx, Identified, MinimalTerm, OntologyHierarchy},
+};
+
+use super::{HierarchyAware, MetadataAware, Ontology, TermAware, TermIdx};
+
+pub struct SimpleOntology<I, H, T> {
+    terms: Vec<T>,
+    term_id_to_idx: HashMap<TermId, I>,
+    hierarchy: H,
+    metadata: HashMap<String, String>,
+}
+
+impl<I, H, T> TryFrom<OntologyData<I, T>> for SimpleOntology<I, H, T>
+where
+    I: HierarchyIdx,
+    H: TryFrom<Vec<GraphEdge<I>>, Error = anyhow::Error> + OntologyHierarchy<I>,
+    T: MinimalTerm,
+{
+    type Error = anyhow::Error;
+
+    fn try_from(value: OntologyData<I, T>) -> Result<Self, Self::Error> {
+        // Keep primary terms only
+        let terms: Vec<_> = value
+            .terms
+            .into_iter()
+            .filter(MinimalTerm::is_current)
+            .collect();
+
+        let term_id_to_idx = terms
+            .iter()
+            .enumerate()
+            .flat_map(|(idx, term)| {
+                once((term.identifier().clone(), HierarchyIdx::new(idx))).chain(
+                    term.iter_alt_term_ids()
+                        .map(move |alt| (alt.clone(), HierarchyIdx::new(idx))),
+                )
+            })
+            .collect();
+
+        let hierarchy = H::try_from(value.edges)?;
+        let metadata = value.metadata;
+
+        Ok(Self {
+            terms,
+            term_id_to_idx,
+            hierarchy,
+            metadata,
+        })
+    }
+}
+
+impl<I, H, T> TermAware<I, T> for SimpleOntology<I, H, T>
+where
+    I: TermIdx,
+{
+    fn iter_terms<'a>(&'a self) -> impl Iterator<Item = &T>
+    where
+        T: 'a,
+    {
+        self.terms.iter()
+    }
+
+    fn idx_to_term(&self, idx: &I) -> Option<&T> {
+        self.terms.get(TermIdx::index(idx))
+    }
+
+    fn id_to_idx<ID>(&self, id: &ID) -> Option<&I>
+    where
+        ID: Identified,
+    {
+        self.term_id_to_idx.get(id.identifier())
+    }
+}
+
+impl<I, H, T> HierarchyAware<I> for SimpleOntology<I, H, T>
+where
+    H: OntologyHierarchy<I>,
+{
+    type Hierarchy = H;
+
+    fn hierarchy(&self) -> &Self::Hierarchy {
+        &self.hierarchy
+    }
+}
+
+impl<I, H, T> MetadataAware for SimpleOntology<I, H, T> {
+    fn version(&self) -> &str {
+        self.metadata
+            .get("version")
+            .map(|a| a.as_str())
+            .unwrap_or("Whoa, a missing version!")
+    }
+}
+
+impl<I, H, T> Ontology<I, T> for SimpleOntology<I, H, T>
+where
+    I: TermIdx,
+    H: OntologyHierarchy<I>,
+{
+    fn root_term(&self) -> &T {
+        self.idx_to_term(self.hierarchy().root())
+            .expect("Ontology should contain a term for term index")
+    }
+
+    fn root_term_id<'a>(&'a self) -> &'a TermId
+    where
+        T: Identified + 'a,
+    {
+        self.root_term().identifier()
+    }
+}

--- a/src/ontology/simple.rs
+++ b/src/ontology/simple.rs
@@ -59,7 +59,7 @@ impl<I, H, T> TermAware<I, T> for SimpleOntology<I, H, T>
 where
     I: TermIdx,
 {
-    fn iter_terms<'a>(&'a self) -> impl Iterator<Item = &T>
+    fn iter_terms<'a>(&'a self) -> impl Iterator<Item = &'a T>
     where
         T: 'a,
     {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -17,7 +17,7 @@ pub use crate::io::OntologyLoader;
 pub use crate::io::OntologyLoaderBuilder;
 
 pub use crate::ontology::HierarchyAware;
+pub use crate::ontology::MetadataAware;
 pub use crate::ontology::Ontology;
 pub use crate::ontology::TermAware;
 pub use crate::ontology::TermIdx;
-pub use crate::ontology::MetadataAware;


### PR DESCRIPTION
Simplify trait bounds, make `Ontology` generic over term and term index, unimplement hierarchy indices for signed ints.