### PR TITLE
The CSR graph implementation is controlled by a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,22 +13,21 @@ license-file = "LICENSE"
 authors = ["Daniel Danis <daniel.gordon.danis@protonmail.com>"]
 
 [dependencies]
-graph_builder = "0.3.1"
 anyhow = "1.0.86"
-pyo3 = { version = "0.21.2", optional = true, features = ["abi3-py310"] }
-obographs-dev = { version = "0.2.2", optional = true}
 curieosa = { version = "0.1.0", optional = true }
+graph_builder = { version = "0.3.1", optional = true }
+obographs-dev = { version = "0.2.2", optional = true }
+pyo3 = { version = "0.21.2", optional = true, features = ["abi3-py310"] }
 
 
 [dev-dependencies]
-obographs-dev = "0.2.2"
-curieosa = "0.1.0"
 flate2 = "1.0.30"
 criterion = "0.5.1"
 rstest = "0.22.0"
 
 [features]
 default = ["obographs"]
+csr = ["dep:graph_builder"]
 obographs = ["dep:obographs-dev", "dep:curieosa"]
 pyo3 = ["dep:pyo3"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ criterion = "0.5.1"
 rstest = "0.22.0"
 
 [features]
-default = ["obographs"]
+default = ["obographs", "csr"]
 csr = ["dep:graph_builder"]
 obographs = ["dep:obographs-dev", "dep:curieosa"]
 pyo3 = ["dep:pyo3"]

--- a/src/ontology/mod.rs
+++ b/src/ontology/mod.rs
@@ -1,4 +1,5 @@
 //! A module with the ontology parts.
+#[cfg(feature = "csr")]
 pub mod csr;
 mod simple;
 


### PR DESCRIPTION
We do not want to impose the CSR impl and the associated dependencies on the users. Therefore, we add a `csr` feature.

The feature is enabled by default. However, it will most likely be removed from the default features in one of future releases.