### PR TITLE
Add `ontolius::common` with common term IDs

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,0 +1,57 @@
+//! The module with constants for working with various ontologies.
+
+use crate::{
+    term_id::{InnerTermId, Prefix},
+    TermId,
+};
+
+/// A private function for streamlining creation of well-known term IDs.
+const fn make_term_id(prefix: Prefix, id: u32, len: u8) -> TermId {
+    TermId::from_inner(InnerTermId::Known(prefix, id, len))
+}
+
+/// Constants for working with Human Phenotype Ontology (HPO).
+pub mod hpo {
+    use crate::{term_id::Prefix, TermId};
+
+    use super::make_term_id;
+    /// [All (HP:0000001)](http://purl.obolibrary.org/obo/HP_0000001)
+    /// is the root of all terms in the HPO.
+    pub const ALL: TermId = make_term_id(Prefix::HP, 0000001, 7);
+
+    /// [Phenotypic abnormality (HP:0000118)](http://purl.obolibrary.org/obo/HP_0000118)
+    /// is the root of the phenotypic abnormality sub-module of the HPO.
+    pub const PHENOTYPIC_ABNORMALITY: TermId = make_term_id(Prefix::HP, 0000118, 7);
+
+    /// [Clinical modifier (HP:0012823)](http://purl.obolibrary.org/obo/HP_0012823)
+    /// is the root of HPO's submodule with terms to characterize
+    /// and specify the phenotypic abnormalities defined in the Phenotypic abnormality subontology,
+    /// with respect to severity, laterality, age of onset, and other aspects.
+    pub const CLINICAL_MODIFIER: TermId = make_term_id(Prefix::HP, 0012823, 7);
+}
+
+/// Constants for working with Medical Action Ontology (MAxO).
+pub mod maxo {
+    use crate::{term_id::Prefix, TermId};
+
+    use super::make_term_id;
+    /// [medical action (MAXO:0000001)](http://purl.obolibrary.org/obo/MAXO_0000001)
+    /// is the root of all terms in the MAxO.
+    pub const MEDICAL_ACTION: TermId = make_term_id(Prefix::MAXO, 0000001, 7);
+}
+
+/// Constants for working with Gene Ontology (GO).
+pub mod go {
+    use crate::{term_id::Prefix, TermId};
+
+    use super::make_term_id;
+    /// [biological process (GO:0008150)](http://purl.obolibrary.org/obo/GO_0008150)
+    /// is one of three roots of the GO.
+    pub const BIOLOGICAL_PROCESS: TermId = make_term_id(Prefix::GO, 0008150, 7);
+    /// [cellular component (GO:0005575)](http://purl.obolibrary.org/obo/GO_0005575)
+    /// is one of three roots of the GO.
+    pub const CELLULAR_COMPONENT: TermId = make_term_id(Prefix::GO, 0005575, 7);
+    /// [molecular function (GO:0003674)](http://purl.obolibrary.org/obo/GO_0003674)
+    /// is one of three roots of the GO.
+    pub const MOLECULAR_FUNCTION: TermId = make_term_id(Prefix::GO, 0003674, 7);
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -38,13 +38,16 @@ pub trait OntologyDataParser<I, T> {
 }
 
 /// [`OntologyLoader`] parses the input into [`OntologyData`] using supplied [`OntologyDataParser`]
-/// and then assembles the data into an [`crate::ontology::Ontology`].
+/// and then assembles the data into an ontology.
+/// 
+/// Use [`OntologyLoaderBuilder`] to create the loader and load ontology from a path,
+/// read, or buf read.
 pub struct OntologyLoader<P> {
     parser: P,
 }
 
 impl<P> OntologyLoader<P> {
-    pub fn new(parser: P) -> Self {
+    fn new(parser: P) -> Self {
         Self { parser }
     }
 }
@@ -91,10 +94,13 @@ pub struct WithParser<P> {
     parser: P,
 }
 
+/// A builder for configuring [`OntologyLoader`].
+/// 
 pub struct OntologyLoaderBuilder<State> {
     state: State,
 }
 
+/// Creates a new "blank" builder.
 impl Default for OntologyLoaderBuilder<Uninitialized> {
     fn default() -> Self {
         Self {
@@ -119,7 +125,7 @@ impl OntologyLoaderBuilder<Uninitialized> {
 }
 
 impl<P> OntologyLoaderBuilder<WithParser<P>> {
-    /// Build the ontology loader.
+    /// Finish the build and get the ontology loader.
     pub fn build(self) -> OntologyLoader<P> {
         OntologyLoader::new(self.state.parser)
     }

--- a/src/io/obographs.rs
+++ b/src/io/obographs.rs
@@ -1,3 +1,4 @@
+//! Load ontology data from Obographs formats.
 use std::io::BufRead;
 use std::{collections::HashMap, sync::Arc};
 
@@ -314,7 +315,20 @@ fn parse_relationship(pred: &str) -> Result<Relationship> {
 
 /// Add a convenience function for using [`ObographsParser`] to [`OntologyLoaderBuilder`].
 impl OntologyLoaderBuilder<Uninitialized> {
-    /// Load ontology graphs using [`ObographsParser`].        
+    /// Load ontology graphs using [`ObographsParser`].
+    /// 
+    /// ## Example
+    /// 
+    /// Configure a loader for loading ontology
+    /// from an Obographs JSON file.
+    /// 
+    /// ```
+    /// use ontolius::io::OntologyLoaderBuilder;
+    /// 
+    /// let builder = OntologyLoaderBuilder::new()
+    ///                 .obographs_parser()
+    ///                 .build();
+    /// ```
     #[must_use]
     pub fn obographs_parser(
         self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,3 +11,5 @@ mod term_id;
 pub use term_id::{Identified, TermId};
 #[cfg(feature = "pyo3")]
 pub mod py;
+
+pub mod common;

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,6 +1,7 @@
+//! Ontology term models.
+//!
+//! The module includes traits and structs for modeling ontology terms.
 use crate::{Identified, TermId};
-
-const OWL_THING: (&str, &str) = ("owl", "Thing");
 
 /// Some terms have alternate identifiers,
 /// e.g. the identifiers used to refer to the term in the past.
@@ -20,23 +21,7 @@ pub trait AltTermIdAware {
 ///
 /// On top of inherited traits, such as [`Identified`], [`AltTermIdAware`], and others,
 /// the term must have a name and it is either current or obsolete.
-///
-/// ### Default term
-///
-/// The [`Default`] minimal term represents the ontology root that is inserted into the ontology
-/// in case 2 or more root candidates are found.
-///
-/// #### Example
-///
-/// Gene Ontology has 3 root terms:
-/// * biological process
-/// * molecular function
-/// * cellular component
-///
-/// In this case, a default term would be created to be used as an artificial root term,
-/// and three new "is_a" edges would be created to link the 3 roots to the default term,
-/// which would be used as an artificial root.
-pub trait MinimalTerm: Identified + AltTermIdAware + Default {
+pub trait MinimalTerm: Identified + AltTermIdAware {
     /// Get the name of the term, e.g. `Seizure` for [Seizure](https://hpo.jax.org/browse/term/HP:0001250).
     fn name(&self) -> &str;
 
@@ -116,7 +101,6 @@ pub trait Term: MinimalTerm {
 
 pub mod simple {
 
-    use super::OWL_THING;
     use super::{
         AltTermIdAware, CrossReferenced, Definition, MinimalTerm, Synonym, Synonymous, Term,
     };
@@ -141,18 +125,6 @@ pub mod simple {
                 name: name.to_string(),
                 alt_term_ids: alt_term_ids.into(),
                 is_obsolete,
-            }
-        }
-    }
-
-    /// Get the default term that corresponds to `owl:Thing`.
-    impl Default for SimpleMinimalTerm {
-        fn default() -> Self {
-            Self {
-                term_id: TermId::from(OWL_THING),
-                alt_term_ids: Default::default(),
-                name: "Thing".to_string(),
-                is_obsolete: false,
             }
         }
     }
@@ -224,21 +196,6 @@ pub mod simple {
                 comment,
                 synonyms,
                 xrefs,
-            }
-        }
-    }
-
-    impl Default for SimpleTerm {
-        fn default() -> Self {
-            Self {
-                term_id: TermId::from(OWL_THING),
-                alt_term_ids: Default::default(),
-                name: "Thing".to_string(),
-                is_obsolete: false,
-                definition: Default::default(),
-                comment: Default::default(),
-                synonyms: Default::default(),
-                xrefs: Default::default(),
             }
         }
     }

--- a/src/term_id.rs
+++ b/src/term_id.rs
@@ -161,6 +161,12 @@ impl From<InnerTermId> for TermId {
     }
 }
 
+impl TermId {
+    pub(crate) const fn from_inner(inner: InnerTermId) -> Self {
+        TermId(inner)
+    }
+}
+
 impl Display for TermId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
@@ -170,7 +176,7 @@ impl Display for TermId {
 // We really want to have all these private enum members in upper case!
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-enum Prefix {
+pub(crate) enum Prefix {
     // TODO: others?
     HP,
     OMIM,
@@ -234,7 +240,7 @@ impl TryFrom<&str> for Prefix {
 }
 
 #[derive(Debug, Clone)]
-enum InnerTermId {
+pub(crate) enum InnerTermId {
     // Most of the time we will have a CURIE that has a known Prefix and an integral id.
     // We store the prefix, the id, and the length of the id (e.g. 7 for HP:1234567 or 6 for OMIM:256000)
     Known(Prefix, u32, u8),


### PR DESCRIPTION
Add `ontolius::common` with common term IDs. Improve documentation.