### PR TITLE
Add iterator adapters for including `query` into hierarchy walk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ pyo3 = { version = "0.21.2", optional = true, features = ["abi3-py310"] }
 [dev-dependencies]
 flate2 = "1.0.30"
 criterion = "0.5.1"
-rstest = "0.22.0"
 
 [features]
 default = ["obographs", "csr"]

--- a/src/ontology/api.rs
+++ b/src/ontology/api.rs
@@ -1,8 +1,10 @@
+use std::iter::once;
+
 use crate::term::{AltTermIdAware, MinimalTerm};
 use crate::{Identified, TermId};
 
 /// A container of ontology terms.
-/// 
+///
 /// `T` is the ontology term type.
 pub trait OntologyTerms<T> {
     /// Get the iterator over the *primary* ontology terms.
@@ -154,20 +156,52 @@ pub trait HierarchyWalks {
     where
         I: Identified;
 
+    /// Returns an iterator that includes term ID belonging to the `query` as well as its parents.
+    fn iter_term_and_parent_ids<'a, I>(&'a self, query: &'a I) -> impl Iterator<Item = &'a TermId>
+    where
+        I: Identified,
+    {
+        once(query.identifier()).chain(self.iter_parent_ids(query.identifier()))
+    }
+
     /// Returns an iterator of all nodes which are children of `query`.
     fn iter_child_ids<'a, I>(&'a self, query: &I) -> impl Iterator<Item = &'a TermId>
     where
         I: Identified;
+
+    /// Returns an iterator that includes term ID belonging to the `query` as well as its children.
+    fn iter_term_and_child_ids<'a, I>(&'a self, query: &'a I) -> impl Iterator<Item = &'a TermId>
+    where
+        I: Identified,
+    {
+        once(query.identifier()).chain(self.iter_child_ids(query.identifier()))
+    }
 
     /// Returns an iterator of all nodes which are ancestors of `query`.
     fn iter_ancestor_ids<'a, I>(&'a self, query: &I) -> impl Iterator<Item = &'a TermId>
     where
         I: Identified;
 
+    /// Returns an iterator that includes term ID belonging to the `query` as well as its ancestors.
+    fn iter_term_and_ancestor_ids<'a, I>(&'a self, query: &'a I) -> impl Iterator<Item = &'a TermId>
+    where
+        I: Identified,
+    {
+        once(query.identifier()).chain(self.iter_ancestor_ids(query.identifier()))
+    }
+
     /// Returns an iterator of all nodes which are descendants of `query`.
     fn iter_descendant_ids<'a, I>(&'a self, query: &I) -> impl Iterator<Item = &'a TermId>
     where
         I: Identified;
+
+    /// Returns an iterator that includes term ID belonging to the `query` as well as its ancestors.
+    fn iter_term_and_descendant_ids<'a, I>(&'a self, query: &'a I) -> impl Iterator<Item = &'a TermId>
+    where
+        I: Identified,
+    {
+        once(query.identifier()).chain(self.iter_descendant_ids(query.identifier()))
+    }
 }
 
 /// Tests if an ontology term is a parent, a child, an ancestor, or descendant of another term.


### PR DESCRIPTION
Add iterator adapters for including `query` into hierarchy walks.