### PR TITLE
Common `TermId`s are `static` items (not `const`)

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -10,6 +10,7 @@ const fn make_term_id(prefix: Prefix, id: u32, len: u8) -> TermId {
     TermId::from_inner(InnerTermId::Known(prefix, id, len))
 }
 
+// TODO: should in fact be static constants!
 /// Constants for working with Human Phenotype Ontology (HPO).
 pub mod hpo {
     use crate::{term_id::Prefix, TermId};
@@ -17,17 +18,17 @@ pub mod hpo {
     use super::make_term_id;
     /// [All (HP:0000001)](http://purl.obolibrary.org/obo/HP_0000001)
     /// is the root of all terms in the HPO.
-    pub const ALL: TermId = make_term_id(Prefix::HP, 1, 7);
+    pub static ALL: TermId = make_term_id(Prefix::HP, 1, 7);
 
     /// [Phenotypic abnormality (HP:0000118)](http://purl.obolibrary.org/obo/HP_0000118)
     /// is the root of the phenotypic abnormality sub-module of the HPO.
-    pub const PHENOTYPIC_ABNORMALITY: TermId = make_term_id(Prefix::HP, 118, 7);
+    pub static PHENOTYPIC_ABNORMALITY: TermId = make_term_id(Prefix::HP, 118, 7);
 
     /// [Clinical modifier (HP:0012823)](http://purl.obolibrary.org/obo/HP_0012823)
     /// is the root of HPO's submodule with terms to characterize
     /// and specify the phenotypic abnormalities defined in the Phenotypic abnormality subontology,
     /// with respect to severity, laterality, age of onset, and other aspects.
-    pub const CLINICAL_MODIFIER: TermId = make_term_id(Prefix::HP, 12823, 7);
+    pub static CLINICAL_MODIFIER: TermId = make_term_id(Prefix::HP, 12823, 7);
 }
 
 /// Constants for working with Medical Action Ontology (MAxO).
@@ -37,7 +38,7 @@ pub mod maxo {
     use super::make_term_id;
     /// [medical action (MAXO:0000001)](http://purl.obolibrary.org/obo/MAXO_0000001)
     /// is the root of all terms in the MAxO.
-    pub const MEDICAL_ACTION: TermId = make_term_id(Prefix::MAXO, 1, 7);
+    pub static MEDICAL_ACTION: TermId = make_term_id(Prefix::MAXO, 1, 7);
 }
 
 /// Constants for working with Gene Ontology (GO).
@@ -47,11 +48,11 @@ pub mod go {
     use super::make_term_id;
     /// [biological process (GO:0008150)](http://purl.obolibrary.org/obo/GO_0008150)
     /// is one of three roots of the GO.
-    pub const BIOLOGICAL_PROCESS: TermId = make_term_id(Prefix::GO, 8150, 7);
+    pub static BIOLOGICAL_PROCESS: TermId = make_term_id(Prefix::GO, 8150, 7);
     /// [cellular component (GO:0005575)](http://purl.obolibrary.org/obo/GO_0005575)
     /// is one of three roots of the GO.
-    pub const CELLULAR_COMPONENT: TermId = make_term_id(Prefix::GO, 5575, 7);
+    pub static CELLULAR_COMPONENT: TermId = make_term_id(Prefix::GO, 5575, 7);
     /// [molecular function (GO:0003674)](http://purl.obolibrary.org/obo/GO_0003674)
     /// is one of three roots of the GO.
-    pub const MOLECULAR_FUNCTION: TermId = make_term_id(Prefix::GO, 3674, 7);
+    pub static MOLECULAR_FUNCTION: TermId = make_term_id(Prefix::GO, 3674, 7);
 }

--- a/src/term_id.rs
+++ b/src/term_id.rs
@@ -188,6 +188,7 @@ pub(crate) enum Prefix {
     SO,
     CHEBI,
     NCIT,
+    PMID,
 }
 
 impl PartialEq<str> for Prefix {
@@ -203,6 +204,7 @@ impl PartialEq<str> for Prefix {
             Prefix::SO => other == "SO",
             Prefix::CHEBI => other == "CHEBI",
             Prefix::NCIT => other == "NCIT",
+            Prefix::PMID => other == "PMID",
         }
     }
 }
@@ -233,6 +235,8 @@ impl TryFrom<&str> for Prefix {
             Ok(Prefix::CHEBI)
         } else if value.starts_with("NCIT") {
             Ok(Prefix::NCIT)
+        } else if value.starts_with("PMID") {
+            Ok(Prefix::PMID)
         } else {
             Err(())
         }

--- a/tests/test_common.rs
+++ b/tests/test_common.rs
@@ -1,0 +1,20 @@
+use ontolius::common::{hpo, go, maxo};
+
+#[test]
+fn hpo_commons_are_accessible() {
+    assert_eq!(hpo::PHENOTYPIC_ABNORMALITY, ("HP", "0000118"));
+    assert_eq!(hpo::ALL, ("HP", "0000001"));
+    assert_eq!(hpo::CLINICAL_MODIFIER, ("HP", "0012823"));
+}
+
+#[test]
+fn go_commons_are_accessible() {
+    assert_eq!(go::BIOLOGICAL_PROCESS, ("GO", "0008150"));
+    assert_eq!(go::CELLULAR_COMPONENT, ("GO", "0005575"));
+    assert_eq!(go::MOLECULAR_FUNCTION, ("GO", "0003674"));
+}
+
+#[test]
+fn maxo_commons_are_accessible() {
+    assert_eq!(maxo::MEDICAL_ACTION, ("MAXO", "0000001"))
+}


### PR DESCRIPTION
Items from `ontolius::common` are `static` and not `const`. The intended use case is to have a constant at a single memory address, and not inline the constant at all use cases.