### PR TITLE
Dependencies: Add rayon 1.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,11 @@ curieosa = { version = "0.1.0", optional = true }
 graph_builder = { version = "0.3.1", optional = true }
 obographs-dev = { version = "0.2.2", optional = true }
 pyo3 = { version = "0.24.1", optional = true, features = ["abi3-py310"] }
-rayon = "=1.10.0" # Ontolius will not compile without, because there is an error upstream in the graph_builder crate
+# Ontolius will not compile without pinning `rayon=1.10.0`
+# because there is an error upstream in the `graph_builder` crate.
+# The dependency restriction can be removed after the error is fixed.
+# https://github.com/neo4j-labs/graph/issues/138
+rayon = { version = "=1.10.0", optional = true }
 
 [dev-dependencies]
 flate2 = "1.0.30"
@@ -26,7 +30,7 @@ criterion = "0.5.1"
 
 [features]
 default = ["obographs", "csr"]
-csr = ["dep:graph_builder"]
+csr = ["dep:graph_builder", "dep:rayon"]
 obographs = ["dep:obographs-dev", "dep:curieosa"]
 pyo3 = ["dep:pyo3"]
 


### PR DESCRIPTION
Ontolius will not compile without, because there is an error upstream in the graph_builder crate.

Issues:
- https://github.com/ielis/ontolius/issues/43
- https://github.com/neo4j-labs/graph/issues/138