### PR TITLE
Fix hashing of `ontolius::Prefix`

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -21,7 +21,7 @@ pub mod hpo {
     pub static ALL: TermId = make_term_id(KnownPrefix::HP, 1, 7);
 
     /// [Phenotypic abnormality (HP:0000118)](http://purl.obolibrary.org/obo/HP_0000118)
-    /// is the root of the phenotypic abnormality sub-module of the HPO.
+    /// is the root of the phenotypic abnormality submodule of the HPO.
     pub static PHENOTYPIC_ABNORMALITY: TermId = make_term_id(KnownPrefix::HP, 118, 7);
 
     /// [Clinical modifier (HP:0012823)](http://purl.obolibrary.org/obo/HP_0012823)

--- a/src/io/obographs.rs
+++ b/src/io/obographs.rs
@@ -222,7 +222,8 @@ where
                             Self::parse_alt_term_ids(&meta),
                             meta.deprecated.unwrap_or(false),
                             Self::parse_comment(meta.comments),
-                            meta.definition.map(|d| Definition::try_from(d).unwrap_or_default()), // Ignores an unparsable definition.
+                            meta.definition
+                                .map(|d| Definition::try_from(d).unwrap_or_default()), // Ignores an unparsable definition.
                             meta.synonyms
                                 .into_iter()
                                 .flat_map(Synonym::try_from) // Ignores unparsable synonyms.

--- a/src/io/obographs.rs
+++ b/src/io/obographs.rs
@@ -22,7 +22,7 @@ use super::{
 
 impl TryFrom<DefinitionPropertyValue> for Definition {
     type Error = Infallible; // Can be replaced with a more specific error in the future.
-    fn try_from(value: DefinitionPropertyValue) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: DefinitionPropertyValue) -> Result<Self, Self::Error> {
         Ok(Definition {
             val: value.val,
             xrefs: value.xrefs.unwrap_or_default(),
@@ -138,11 +138,11 @@ pub trait ObographsTermMapper<T> {
 }
 
 /// `DefaultObographsTermMapper` parses the obograph term nodes
-/// into [[SimpleMinimalTerm]] or into [[SimpleTerm]] for a downstream use.
+/// into [`SimpleMinimalTerm`] or into [`SimpleTerm`] for a downstream use.
 ///
 /// ### Mapping behavior
 ///
-/// The errors encountered while parsing the mandatory fields of [[crate::term::MinimalTerm]] (or [[crate::term::Term]]) are reported as errors.
+/// The errors encountered while parsing the mandatory fields of [[MinimalTerm]] (or [[crate::term::Term]]) are reported as errors.
 /// However, the errors in the optional parts (e.g. one of the alternative term IDs or synonym) are *ignored*.
 ///
 #[derive(Default)]

--- a/src/io/obographs.rs
+++ b/src/io/obographs.rs
@@ -125,9 +125,9 @@ impl TryFrom<SynonymPropertyValue> for Synonym {
 
         Ok(Self {
             name: value.val,
-            category: category,
+            category,
             r#type: synonym_type,
-            xrefs: xrefs,
+            xrefs,
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,4 +9,4 @@ pub mod py;
 pub mod term;
 mod term_id;
 
-pub use term_id::{Identified, TermId, Prefix, TermIdParseError};
+pub use term_id::{Identified, Prefix, TermId, TermIdParseError};

--- a/src/ontology/api.rs
+++ b/src/ontology/api.rs
@@ -196,7 +196,10 @@ pub trait HierarchyWalks {
         I: Identified;
 
     /// Returns an iterator that includes term ID belonging to the `query` as well as its ancestors.
-    fn iter_term_and_descendant_ids<'a, I>(&'a self, query: &'a I) -> impl Iterator<Item = &'a TermId>
+    fn iter_term_and_descendant_ids<'a, I>(
+        &'a self,
+        query: &'a I,
+    ) -> impl Iterator<Item = &'a TermId>
     where
         I: Identified,
     {

--- a/src/term.rs
+++ b/src/term.rs
@@ -20,7 +20,7 @@ pub trait AltTermIdAware {
 /// `MinimalTerm` describes the minimal requirements of an ontology term.
 ///
 /// On top of inherited traits, such as [`Identified`], [`AltTermIdAware`], and others,
-/// the term must have a name and it is either current or obsolete.
+/// the term must have a name, and it is either current or obsolete.
 pub trait MinimalTerm: Identified + AltTermIdAware {
     /// Get the name of the term, e.g. `Seizure` for [Seizure](https://hpo.jax.org/browse/term/HP:0001250).
     fn name(&self) -> &str;

--- a/src/term_id.rs
+++ b/src/term_id.rs
@@ -328,7 +328,7 @@ impl Hash for Prefix<'_> {
                 kp.hash(state);
             }
             InnerTermId::Random(val, offset) => {
-                (&val[..(*offset as usize)]).hash(state);
+                val[..(*offset as usize)].hash(state);
             }
         }
     }

--- a/src/term_id.rs
+++ b/src/term_id.rs
@@ -3,7 +3,7 @@
 use std::cmp::Ordering;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 
 /// `Identified` is implemented by entities that have a [`TermId`] as an identifier.
@@ -177,7 +177,7 @@ impl PartialEq<(&str, &str)> for &TermId {
 ///
 /// ```should_panic
 /// # use ontolius::TermId;
-///
+/// #
 /// // A string concatenated from 256 `'A'` characters
 /// let many_as: String = std::iter::repeat('A').take(256).collect();
 /// let term_id = TermId::from((many_as.as_str(), "0001250"));
@@ -187,7 +187,7 @@ impl PartialEq<(&str, &str)> for &TermId {
 ///
 /// ```should_panic
 /// # use ontolius::TermId;
-///
+/// #
 /// // A string concatenated from 256 `'0'` characters
 /// let many_zeros: String = std::iter::repeat('0').take(256).collect();
 /// let term_id = TermId::from(("HP", many_zeros.as_str()));
@@ -261,14 +261,16 @@ impl Display for TermId {
 /// Note that no *particular* order (e.g. alphabetical) is guaranteed.
 /// Only that the ordering is defined.
 ///
-/// Prefix implements [`std::fmt::Debug`] and [`std::fmt::Display`].
+/// Prefix can be hashed ([`Hash`]).
+///
+/// Prefix implements [`std::fmt::Debug`] and [`Display`].
 /// ```
 /// # use ontolius::TermId;
 /// # let seizure: TermId = "HP:0001250".parse().unwrap();
 /// # let prefix = seizure.prefix();
 /// assert_eq!(prefix.to_string(), String::from("HP"));
 /// ```
-#[derive(Clone, Debug, Eq, PartialOrd, Hash)]
+#[derive(Clone, Debug, Eq, PartialOrd)]
 pub struct Prefix<'a>(&'a TermId);
 
 impl PartialEq for Prefix<'_> {
@@ -319,24 +321,67 @@ impl Display for Prefix<'_> {
     }
 }
 
+impl Hash for Prefix<'_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match &self.0 .0 {
+            InnerTermId::Known(kp, _, _) => {
+                kp.hash(state);
+            }
+            InnerTermId::Random(val, offset) => {
+                (&val[..(*offset as usize)]).hash(state);
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_prefix {
     use super::TermId;
+    use std::hash::{DefaultHasher, Hash, Hasher};
 
     #[test]
     fn partial_eq() {
         let seizure: TermId = "HP:0001250".parse().unwrap();
         let arachnodactyly: TermId = "HP:0001166".parse().unwrap();
 
-        assert!(seizure.prefix() == arachnodactyly.prefix());
+        assert_eq!(seizure.prefix(), arachnodactyly.prefix());
+    }
+
+    #[test]
+    fn hash_known_prefix() {
+        let seizure: TermId = "HP:0001250".parse().unwrap();
+        let mut seizure_hasher = DefaultHasher::new();
+        seizure.prefix().hash(&mut seizure_hasher);
+        let seizure_hash = seizure_hasher.finish();
+
+        let arachnodactyly: TermId = "HP:0001166".parse().unwrap();
+        let mut arachnodactyly_hasher = DefaultHasher::new();
+        arachnodactyly.prefix().hash(&mut arachnodactyly_hasher);
+        let arachnodactyly_hash = arachnodactyly_hasher.finish();
+
+        assert_eq!(seizure_hash, arachnodactyly_hash);
+    }
+
+    #[test]
+    fn hash_unknown_prefix() {
+        let one: TermId = "WHATNOT:1".parse().unwrap();
+        let mut one_hasher = DefaultHasher::new();
+        one.prefix().hash(&mut one_hasher);
+        let one_hash = one_hasher.finish();
+
+        let two: TermId = "WHATNOT:2".parse().unwrap();
+        let mut two_hasher = DefaultHasher::new();
+        two.prefix().hash(&mut two_hasher);
+        let two_hash = two_hasher.finish();
+
+        assert_eq!(one_hash, two_hash);
     }
 
     #[test]
     fn partial_eq_with_str() {
         let seizure: TermId = "HP:0001250".parse().unwrap();
-        let prefix = seizure.prefix();
 
-        assert!(&prefix == "HP");
+        assert_eq!(&seizure.prefix(), "HP");
     }
 
     #[test]
@@ -437,29 +482,21 @@ impl TryFrom<&str> for KnownPrefix {
 
 #[cfg(test)]
 mod test_known_prefix {
-    use super::{KnownPrefix, TermId};
+    use super::KnownPrefix;
 
     #[test]
     fn partial_eq_with_str() {
-        assert!(&KnownPrefix::HP == "HP");
-        assert!(&KnownPrefix::HP != "SO");
+        assert_eq!(&KnownPrefix::HP, "HP");
+        assert_ne!(&KnownPrefix::HP, "SO");
 
-        assert!(&KnownPrefix::SO == "SO");
-        assert!(&KnownPrefix::PMID == "PMID");
-    }
-
-    #[test]
-    fn partial_eq() {
-        let seizure: TermId = "HP:0001250".parse().unwrap();
-        let arachnodactyly: TermId = "HP:0001166".parse().unwrap();
-
-        assert_eq!(seizure.prefix(), arachnodactyly.prefix());
+        assert_eq!(&KnownPrefix::SO, "SO");
+        assert_eq!(&KnownPrefix::PMID, "PMID");
     }
 
     #[test]
     fn display() {
-        assert!(&KnownPrefix::HP.to_string() == "HP");
-        assert!(&KnownPrefix::SO.to_string() == "SO");
+        assert_eq!(&KnownPrefix::HP.to_string(), "HP");
+        assert_eq!(&KnownPrefix::SO.to_string(), "SO");
     }
 }
 
@@ -556,13 +593,13 @@ impl PartialEq<Self> for InnerTermId {
 
 impl Eq for InnerTermId {}
 
-impl std::cmp::PartialOrd for InnerTermId {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+impl PartialOrd for InnerTermId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl std::cmp::Ord for InnerTermId {
+impl Ord for InnerTermId {
     fn cmp(&self, other: &Self) -> Ordering {
         if std::mem::discriminant(self) == std::mem::discriminant(other) {
             // Comparing the same enum variants.
@@ -587,8 +624,8 @@ impl std::cmp::Ord for InnerTermId {
     }
 }
 
-impl std::hash::Hash for InnerTermId {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+impl Hash for InnerTermId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
         match self {
             InnerTermId::Known(prefix, id, _) => {
                 prefix.hash(state);
@@ -697,7 +734,6 @@ mod test_comparison_and_ordering {
 
 #[cfg(test)]
 mod test_equalities {
-
     use super::*;
 
     macro_rules! term_ids_partial_eq {
@@ -726,7 +762,6 @@ mod test_equalities {
 
 #[cfg(test)]
 mod test_sizes {
-
     use std::mem::size_of;
 
     use super::InnerTermId;

--- a/src/term_id.rs
+++ b/src/term_id.rs
@@ -646,7 +646,6 @@ impl Identified for TermId {
 
 #[cfg(test)]
 mod test_creation {
-
     use super::TermId;
 
     #[test]

--- a/tests/test_common.rs
+++ b/tests/test_common.rs
@@ -1,4 +1,4 @@
-use ontolius::common::{hpo, go, maxo};
+use ontolius::common::{go, hpo, maxo};
 
 #[test]
 fn hpo_commons_are_accessible() {

--- a/tests/test_io.rs
+++ b/tests/test_io.rs
@@ -21,10 +21,12 @@ mod human_phenotype_ontology {
             let reader = GzDecoder::new(BufReader::new(
                 File::open(HPO_PATH).expect("Obographs JSON file should exist"),
             ));
-            
+
             let loader = OntologyLoaderBuilder::new().obographs_parser().build();
 
-            loader.load_from_read(reader).expect("Obographs JSON should be well formatted")
+            loader
+                .load_from_read(reader)
+                .expect("Obographs JSON should be well formatted")
         })
     }
 
@@ -174,7 +176,9 @@ mod gene_ontology {
                 File::open(TOY_GO_PATH).expect("Obographs JSON file should exist"),
             ));
             let loader = OntologyLoaderBuilder::new().obographs_parser().build();
-            loader.load_from_read(reader).expect("Obographs JSON should be well formatted")
+            loader
+                .load_from_read(reader)
+                .expect("Obographs JSON should be well formatted")
         })
     }
 
@@ -279,7 +283,9 @@ mod medical_action_ontology {
                 File::open(TOY_MAXO_PATH).expect("Obographs JSON file should exist"),
             ));
             let loader = OntologyLoaderBuilder::new().obographs_parser().build();
-            loader.load_from_read(reader).expect("Obographs JSON should be well formatted")
+            loader
+                .load_from_read(reader)
+                .expect("Obographs JSON should be well formatted")
         })
     }
 


### PR DESCRIPTION
The hashing of `ontolius::Prefix` was flawed. The actual `TermId` was hashed instead of the prefix, violating the `Hash` contract. This is now fixed.