### PR TITLE
Support `serde` serialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install ${{ matrix.toolchain }}
+      - name: Install stable
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: "stable"
 
       - name: Run tests
         run: cargo test --features serde,pyo3 --release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,27 +1,40 @@
 name: Run tests
 
 on:
-    push:
-      branches: [ development ]
-    pull_request:
-      branches: [ master, development ]
+  push:
+    branches: [development]
+  pull_request:
+    branches: [master, development]
 
 jobs:
-    run-tests:
-        runs-on: ${{ matrix.os }}
-        strategy:
-            fail-fast: false
-            matrix:
-                os: [ubuntu-latest, macos-latest, windows-latest]
-                toolchain: [stable]
-      
-        steps:
-            - uses: actions/checkout@v4    
-            
-            - name: Install ${{ matrix.toolchain }}
-              uses: dtolnay/rust-toolchain@master
-              with:
-                toolchain: ${{ matrix.toolchain }}
-            
-            - name: Run tests
-              run: cargo test --release
+  run-tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        toolchain: [stable]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ${{ matrix.toolchain }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+
+      - name: Run tests
+        run: cargo test --release
+
+  run-all-features:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ${{ matrix.toolchain }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+
+      - name: Run tests
+        run: cargo test --features serde,pyo3 --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,20 @@ pyo3 = { version = "0.24.1", optional = true, features = ["abi3-py310"] }
 # The dependency restriction can be removed after the error is fixed.
 # https://github.com/neo4j-labs/graph/issues/138
 rayon = { version = "=1.10.0", optional = true }
+serde = { version = "1.0.228", optional = true }
 
 [dev-dependencies]
 flate2 = "1.0.30"
 criterion = "0.5.1"
+serde = "1.0.228"
+serde_test = "1.0.177"
 
 [features]
 default = ["obographs", "csr"]
 csr = ["dep:graph_builder", "dep:rayon"]
 obographs = ["dep:obographs-dev", "dep:curieosa"]
 pyo3 = ["dep:pyo3"]
+serde = ["dep:serde"]
 
 [[bench]]
 name = "hierarchy_io"

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ by default:
 * `obographs` `(*)` - support loading Ontology from Obographs JSON file
 * `pyo3` - include [`crate::py`] module with PyO3 bindings
   to selected data structs to support using from Python
+* `serde` - to provide (de)serialization functions to map [`crate::TermId`] to/from a curie (see `tests/test_serde.rs` for an example)
 
 
 ## Run tests

--- a/src/term_id.rs
+++ b/src/term_id.rs
@@ -232,6 +232,57 @@ impl Display for TermId {
     }
 }
 
+/// Support writing out a [`TermId`] as a curie
+/// when working with `serde`.
+#[cfg(feature = "serde")]
+mod serde {
+
+    use std::str::FromStr;
+
+    use super::TermId;
+
+    impl TermId {
+        pub fn serialize_as_curie<S>(term_id: &TermId, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            // Sadly, we must allocate a string to serialize a curie.
+            let curie = term_id.to_string();
+            serializer.serialize_str(&curie)
+        }
+
+        pub fn deserialize_from_curie<'de, D>(deserializer: D) -> Result<TermId, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            struct TermIdCurieVisitor;
+
+            impl<'de> serde::de::Visitor<'de> for TermIdCurieVisitor {
+                type Value = TermId;
+
+                fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    write!(formatter, "{}", "a curie (e.g. \"HP:0001250\")")
+                }
+
+                fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    match TermId::from_str(v) {
+                        Ok(term_id) => Ok(term_id),
+                        Err(_e) => Err(serde::de::Error::invalid_value(
+                            serde::de::Unexpected::Str(v),
+                            &self,
+                        )),
+                    }
+                }
+            }
+            deserializer.deserialize_str(TermIdCurieVisitor)
+        }
+    }
+}
+
+
 /// The representation of the prefix of a [`TermId`].
 ///
 /// ### Examples

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -1,0 +1,72 @@
+/// An example of serializing a TermId as a CURIE.
+/// 
+/// When working with types that use [`ontolius::TermId`]s and their serialization,
+/// we would like to derive both [`serde::Serialize`] and [`serde::Deserialize`] traits
+/// to enable interoperability with the `serde` crate.
+/// However, we cannot do this directly since [`ontolius::TermId`] does not implement the traits.
+/// 
+/// As a workaround, `serde`` allows using custom serialization and deserialization functions
+/// and `ontolius` provides functions to use with (de)serialization.
+/// 
+/// The functions are available on [`ontolius::TermId`] when the `serde` feature is enabled.
+/// An example usage is shown in this module.
+#[cfg(feature = "serde")]
+mod test_serde {
+
+    use serde;
+    use serde_test::{assert_de_tokens_error, assert_tokens, Token};
+
+    use ontolius::TermId;
+
+    /// An example struct that we want to serialize and deserialize with serde.
+    /// 
+    /// Use the `serde` attributes on the `term_id` field
+    /// to serialize the `TermId` as CURIE.
+    #[derive(PartialEq, Debug, serde::Serialize, serde::Deserialize)]
+    struct Feature {
+        #[serde(
+            serialize_with = "TermId::serialize_as_curie",
+            deserialize_with = "TermId::deserialize_from_curie"
+        )]
+        term_id: TermId,
+    }
+
+    /// Test that serializing `Feature` produces the expected Serde tokens and that
+    /// a valid `Feature` can be created by deserializing those tokens.
+    #[test]
+    fn test_serialize() {
+        let feature = Feature {
+            term_id: TermId::from(("HP", "0001250")),
+        };
+
+        assert_tokens(
+            &feature,
+            &[
+                Token::Struct {
+                    name: "Feature",
+                    len: 1,
+                },
+                Token::Str("term_id"),
+                Token::Str("HP:0001250"),
+                Token::StructEnd,
+            ],
+        )
+    }
+
+    #[test]
+    fn test_malformed_curie_produces_an_error() {
+        let tokens = [
+            Token::Struct {
+                name: "Feature",
+                len: 1,
+            },
+            Token::Str("term_id"),
+            Token::Str("INVALID"),
+            Token::StructEnd,
+        ];
+        assert_de_tokens_error::<Feature>(
+            &tokens,
+            "invalid value: string \"INVALID\", expected a curie (e.g. \"HP:0001250\")",
+        );
+    }
+}


### PR DESCRIPTION
Add `serde` feature to support interoperability with `serde`.

At this point, the PR only adds the support for (de)serializing of the `TermId`, when contained in a struct or an enum. The `TermId` does not implement `serde::Serialize` and `serde::Deserialize` itself, but `serde`, the new Ontolius' feature, exposes the functions to for mapping the `TermId` to a curie.

See `tests/test_serde.rs` module for an example usage.