### PR TITLE
Support `TermId` (de)serialization to/from sequences

### DIFF
--- a/src/io/obographs.rs
+++ b/src/io/obographs.rs
@@ -20,6 +20,7 @@ use super::{
     Uninitialized, WithParser,
 };
 
+#[allow(clippy::infallible_try_from)]
 impl TryFrom<DefinitionPropertyValue> for Definition {
     type Error = Infallible; // Can be replaced with a more specific error in the future.
     fn try_from(value: DefinitionPropertyValue) -> Result<Self, Self::Error> {

--- a/src/term.rs
+++ b/src/term.rs
@@ -204,6 +204,8 @@ pub mod simple {
     }
 
     impl SimpleTerm {
+        // A builder would be an alternative, for now, not going to implement it.
+        #[allow(clippy::too_many_arguments)]
         pub fn new<T, A>(
             term_id: TermId,
             name: T,

--- a/src/term_id.rs
+++ b/src/term_id.rs
@@ -238,7 +238,9 @@ impl Display for TermId {
 #[cfg(feature = "serde")]
 mod serde {
 
-    use std::str::FromStr;
+    use std::{borrow::Cow, collections::HashSet, fmt::Write, str::FromStr};
+
+    use crate::TermIdParseError;
 
     use super::TermId;
 
@@ -252,6 +254,40 @@ mod serde {
             serializer.serialize_str(&curie)
         }
 
+        pub fn serialize_as_curie_seq<'a, S, I>(
+            term_ids: I,
+            serializer: S,
+        ) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+            I: IntoIterator<Item = &'a TermId>,
+        {
+            let iter = term_ids.into_iter();
+            let (lower, _) = iter.size_hint();
+            let mut ser = serializer.serialize_seq(Some(lower))?;
+            let mut buf = String::new();
+            for term_id in iter {
+                write!(&mut buf, "{}", term_id).unwrap();
+                serde::ser::SerializeSeq::serialize_element(&mut ser, buf.as_str())?;
+                buf.clear();
+            }
+            serde::ser::SerializeSeq::end(ser)
+        }
+
+        pub fn serialize_as_curie_set<S>(
+            term_ids: &HashSet<TermId>,
+            serializer: S,
+        ) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            use serde::ser::SerializeSeq;
+            let mut seq = serializer.serialize_seq(Some(term_ids.len()))?;
+            for id in term_ids {
+                seq.serialize_element(&id.to_string())?;
+            }
+            seq.end()
+        }
         pub fn deserialize_from_curie<'de, D>(deserializer: D) -> Result<TermId, D::Error>
         where
             D: serde::Deserializer<'de>,
@@ -262,7 +298,7 @@ mod serde {
                 type Value = TermId;
 
                 fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                    write!(formatter, "{}", "a curie (e.g. \"HP:0001250\")")
+                    write!(formatter, "a curie (e.g. \"HP:0001250\")")
                 }
 
                 fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
@@ -279,6 +315,47 @@ mod serde {
                 }
             }
             deserializer.deserialize_str(TermIdCurieVisitor)
+        }
+
+        pub fn deserialize_from_curie_seq<'de, D, C>(deserializer: D) -> Result<C, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+            C: FromIterator<TermId>,
+        {
+            struct TermIdCuriesVisitor;
+
+            impl<'de> serde::de::Visitor<'de> for TermIdCuriesVisitor {
+                type Value = Vec<TermId>;
+
+                fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    write!(formatter, "a sequence of borrowed or owned strings (e.g. [\"HP:0001250\", \"HP:0000118\"])")
+                }
+
+                fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+                where
+                    A: serde::de::SeqAccess<'de>,
+                {
+                    let mut items = vec![];
+                    while let Some(curie) = seq.next_element::<Cow<'de, str>>()? {
+                        match TermId::from_str(&curie) {
+                            Ok(tid) => items.push(tid),
+                            Err(e) => match e {
+                                TermIdParseError::MissingDelimiter => {
+                                    return Err(serde::de::Error::invalid_value(
+                                        serde::de::Unexpected::Str(&curie),
+                                        &"missing delimiter",
+                                    ))
+                                }
+                            },
+                        }
+                    }
+                    Ok(items)
+                }
+            }
+
+            Ok(C::from_iter(
+                deserializer.deserialize_seq(TermIdCuriesVisitor)?,
+            ))
         }
     }
 }

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -29,6 +29,14 @@ mod test_serde {
             deserialize_with = "TermId::deserialize_from_curie"
         )]
         term_id: TermId,
+
+        /// Use the methods appended with `_seq` to support serialization
+        /// to/from types `T: IntoIterator<TermId> + FromIterator<TermId>`.
+        #[serde(
+            serialize_with = "TermId::serialize_as_curie_seq",
+            deserialize_with = "TermId::deserialize_from_curie_seq"
+        )]
+        alt_term_ids: Vec<TermId>,
     }
 
     /// Test that serializing `Feature` produces the expected Serde tokens and that
@@ -37,6 +45,10 @@ mod test_serde {
     fn test_serialize() {
         let feature = Feature {
             term_id: TermId::from(("HP", "0001250")),
+            alt_term_ids: vec![
+                TermId::from(("HP", "0000123")),
+                TermId::from(("HP", "0000118")),
+            ],
         };
 
         assert_tokens(
@@ -44,10 +56,15 @@ mod test_serde {
             &[
                 Token::Struct {
                     name: "Feature",
-                    len: 1,
+                    len: 2,
                 },
                 Token::Str("term_id"),
                 Token::Str("HP:0001250"),
+                Token::Str("alt_term_ids"),
+                Token::Seq { len: Some(2) },
+                Token::Str("HP:0000123"),
+                Token::Str("HP:0000118"),
+                Token::SeqEnd,
                 Token::StructEnd,
             ],
         )
@@ -58,7 +75,7 @@ mod test_serde {
         let tokens = [
             Token::Struct {
                 name: "Feature",
-                len: 1,
+                len: 2,
             },
             Token::Str("term_id"),
             Token::Str("INVALID"),


### PR DESCRIPTION
Allow `TermId` (de)serialization to/from `T`s that implement `IntoIterator<TermId>` or `FromIterator<TermId>`.

For instance, a `Feature` with an iterable field, such as `alt_term_ids`, can now be serialized:

```rust
#[derive(PartialEq, Debug, serde::Serialize, serde::Deserialize)]
struct Feature {
    #[serde(
        serialize_with = "TermId::serialize_as_curie",
        deserialize_with = "TermId::deserialize_from_curie"
    )]
    term_id: TermId,

    #[serde(
        serialize_with = "TermId::serialize_as_curie_seq",
        deserialize_with = "TermId::deserialize_from_curie_seq"
    )]
    alt_term_ids: Vec<TermId>,
}
```